### PR TITLE
Add lowdb database layer with CRUD API routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "embla-carousel-react": "^8.3.0",
         "express": "^4.19.2",
         "input-otp": "^1.2.4",
+        "lowdb": "^7.0.1",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
         "react": "^18.3.1",
@@ -5943,6 +5944,21 @@
         "@esbuild/win32-x64": "0.25.0"
       }
     },
+    "node_modules/lowdb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-7.0.1.tgz",
+      "integrity": "sha512-neJAj8GwF0e8EpycYIDFqEPcx9Qz4GUho20jWFR7YiFeXzF1YMLdxB36PypcTSPMA+4+LvgyMacYhlr18Zlymw==",
+      "license": "MIT",
+      "dependencies": {
+        "steno": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -7229,6 +7245,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/steno": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/steno/-/steno-4.0.2.tgz",
+      "integrity": "sha512-yhPIQXjrlt1xv7dyPQg2P17URmXbuM5pdGkpiMB3RenprfiBlvK415Lctfe0eshk90oA7/tNq7WEiMK8RSP39A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -44,9 +44,12 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
+    "cors": "^2.8.5",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
+    "express": "^4.19.2",
     "input-otp": "^1.2.4",
+    "lowdb": "^7.0.1",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",
@@ -60,9 +63,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8",
-    "express": "^4.19.2",
-    "cors": "^2.8.5"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,14 @@
+import { Low } from 'lowdb'
+import { JSONFile } from 'lowdb/node'
+
+const adapter = new JSONFile('./server/db.json')
+const db = new Low(adapter, { teams: [], pairings: [], debates: [], scores: [], users: [] })
+
+export async function initDB() {
+  await db.read()
+  db.data ||= { teams: [], pairings: [], debates: [], scores: [], users: [] }
+  await db.write()
+  return db
+}
+
+export default db

--- a/server/db.json
+++ b/server/db.json
@@ -1,0 +1,7 @@
+{
+  "teams": [],
+  "pairings": [],
+  "debates": [],
+  "scores": [],
+  "users": []
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,79 +1,235 @@
-import express from 'express';
-import cors from 'cors';
+import express from 'express'
+import cors from 'cors'
+import db, { initDB } from './db.js'
 
-const app = express();
-app.use(cors());
-app.use(express.json());
+await initDB()
 
-const teams = [
-  {
-    id: 1,
-    name: 'Oxford A',
-    organization: 'Oxford University',
-    speakers: ['Alice Johnson', 'Bob Smith'],
-    wins: 0,
-    losses: 0,
-    speakerPoints: 0,
+const app = express()
+app.use(cors())
+app.use(express.json())
+
+// Helper to save DB after mutation
+const save = () => db.write()
+
+// Teams CRUD
+app.get('/api/teams', async (_req, res) => {
+  await db.read()
+  res.json(db.data.teams)
+})
+
+app.get('/api/teams/:id', async (req, res) => {
+  await db.read()
+  const team = db.data.teams.find(t => t.id === Number(req.params.id))
+  if (!team) return res.status(404).json({ error: 'Not found' })
+  res.json(team)
+})
+
+app.post('/api/teams', async (req, res) => {
+  const team = { id: Date.now(), wins: 0, losses: 0, speakerPoints: 0, ...req.body }
+  db.data.teams.push(team)
+  await save()
+  res.status(201).json(team)
+})
+
+app.put('/api/teams/:id', async (req, res) => {
+  const idx = db.data.teams.findIndex(t => t.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  db.data.teams[idx] = { ...db.data.teams[idx], ...req.body }
+  await save()
+  res.json(db.data.teams[idx])
+})
+
+app.delete('/api/teams/:id', async (req, res) => {
+  const idx = db.data.teams.findIndex(t => t.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  const removed = db.data.teams.splice(idx, 1)
+  await save()
+  res.json(removed[0])
+})
+
+// Pairings CRUD
+app.get('/api/pairings', async (_req, res) => {
+  await db.read()
+  res.json(db.data.pairings)
+})
+
+app.get('/api/pairings/:id', async (req, res) => {
+  await db.read()
+  const pairing = db.data.pairings.find(p => p.id === Number(req.params.id))
+  if (!pairing) return res.status(404).json({ error: 'Not found' })
+  res.json(pairing)
+})
+
+app.post('/api/pairings', async (req, res) => {
+  const pairing = { id: Date.now(), ...req.body }
+  db.data.pairings.push(pairing)
+  await save()
+  res.status(201).json(pairing)
+})
+
+app.put('/api/pairings/:id', async (req, res) => {
+  const idx = db.data.pairings.findIndex(p => p.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  db.data.pairings[idx] = { ...db.data.pairings[idx], ...req.body }
+  await save()
+  res.json(db.data.pairings[idx])
+})
+
+app.delete('/api/pairings/:id', async (req, res) => {
+  const idx = db.data.pairings.findIndex(p => p.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  const removed = db.data.pairings.splice(idx, 1)
+  await save()
+  res.json(removed[0])
+})
+
+// Generate pairings - simplistic
+app.post('/api/pairings/generate', async (_req, res) => {
+  await db.read()
+  const teams = [...db.data.teams]
+  const newPairings = []
+  for (let i = 0; i < teams.length; i += 2) {
+    const prop = teams[i]
+    const opp = teams[i + 1]
+    if (!opp) break
+    newPairings.push({
+      id: Date.now() + i,
+      room: `Room ${i / 2 + 1}`,
+      proposition: prop.name,
+      opposition: opp.name,
+      judge: '',
+      status: 'upcoming',
+      propWins: null
+    })
   }
-];
+  db.data.pairings.push(...newPairings)
+  await save()
+  res.json(newPairings)
+})
 
-const pairings = [
-  {
-    id: 1,
-    room: 'A1',
-    proposition: 'Oxford A',
-    opposition: 'Cambridge B',
-    judge: 'Dr. Sarah Wilson',
-    status: 'completed',
-    propWins: true,
-  }
-];
+// Debates CRUD
+app.get('/api/debates', async (_req, res) => {
+  await db.read()
+  res.json(db.data.debates)
+})
 
-const debates = [
-  {
-    room: 'A1',
-    proposition: 'Oxford A',
-    opposition: 'Cambridge B',
-    judge: 'Dr. Sarah Wilson',
-    status: 'scoring',
-  }
-];
+app.get('/api/debates/:id', async (req, res) => {
+  await db.read()
+  const debate = db.data.debates.find(d => d.id === Number(req.params.id))
+  if (!debate) return res.status(404).json({ error: 'Not found' })
+  res.json(debate)
+})
 
-const scores = {
-  A1: [
-    { speaker: 'Alice Johnson', team: 'Oxford A', position: 'PM', content: 78, style: 82, strategy: 80, total: 240 },
-    { speaker: 'Bob Smith', team: 'Oxford A', position: 'DPM', content: 75, style: 79, strategy: 77, total: 231 },
-  ]
-};
+app.post('/api/debates', async (req, res) => {
+  const debate = { id: Date.now(), ...req.body }
+  db.data.debates.push(debate)
+  await save()
+  res.status(201).json(debate)
+})
 
-app.get('/api/teams', (req, res) => {
-  res.json(teams);
-});
+app.put('/api/debates/:id', async (req, res) => {
+  const idx = db.data.debates.findIndex(d => d.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  db.data.debates[idx] = { ...db.data.debates[idx], ...req.body }
+  await save()
+  res.json(db.data.debates[idx])
+})
 
-app.post('/api/teams', (req, res) => {
-  const team = { id: teams.length + 1, wins: 0, losses: 0, speakerPoints: 0, ...req.body };
-  teams.push(team);
-  res.status(201).json(team);
-});
+app.delete('/api/debates/:id', async (req, res) => {
+  const idx = db.data.debates.findIndex(d => d.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  const removed = db.data.debates.splice(idx, 1)
+  await save()
+  res.json(removed[0])
+})
 
-app.get('/api/pairings', (req, res) => {
-  res.json(pairings);
-});
+// Scores CRUD
+app.get('/api/scores', async (_req, res) => {
+  await db.read()
+  res.json(db.data.scores)
+})
 
-app.post('/api/pairings/generate', (req, res) => {
-  // placeholder generation logic
-  res.json({ status: 'ok' });
-});
+app.get('/api/scores/:room', async (req, res) => {
+  await db.read()
+  const scores = db.data.scores.filter(s => s.room === req.params.room)
+  res.json(scores)
+})
 
-app.get('/api/debates', (req, res) => {
-  res.json(debates);
-});
+app.post('/api/scores', async (req, res) => {
+  const score = { id: Date.now(), ...req.body }
+  db.data.scores.push(score)
+  await save()
+  res.status(201).json(score)
+})
 
-app.get('/api/scores/:room', (req, res) => {
-  res.json(scores[req.params.room] || []);
-});
+app.put('/api/scores/:id', async (req, res) => {
+  const idx = db.data.scores.findIndex(s => s.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  db.data.scores[idx] = { ...db.data.scores[idx], ...req.body }
+  await save()
+  res.json(db.data.scores[idx])
+})
 
-const PORT = process.env.PORT || 3001;
+app.delete('/api/scores/:id', async (req, res) => {
+  const idx = db.data.scores.findIndex(s => s.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  const removed = db.data.scores.splice(idx, 1)
+  await save()
+  res.json(removed[0])
+})
+
+// Submit team and speaker scores
+app.post('/api/scores/team', async (req, res) => {
+  const entry = { id: Date.now(), type: 'team', ...req.body }
+  db.data.scores.push(entry)
+  await save()
+  res.status(201).json(entry)
+})
+
+app.post('/api/scores/speaker', async (req, res) => {
+  const entry = { id: Date.now(), type: 'speaker', ...req.body }
+  db.data.scores.push(entry)
+  await save()
+  res.status(201).json(entry)
+})
+
+// Users CRUD
+app.get('/api/users', async (_req, res) => {
+  await db.read()
+  res.json(db.data.users)
+})
+
+app.get('/api/users/:id', async (req, res) => {
+  await db.read()
+  const user = db.data.users.find(u => u.id === Number(req.params.id))
+  if (!user) return res.status(404).json({ error: 'Not found' })
+  res.json(user)
+})
+
+app.post('/api/users', async (req, res) => {
+  const user = { id: Date.now(), ...req.body }
+  db.data.users.push(user)
+  await save()
+  res.status(201).json(user)
+})
+
+app.put('/api/users/:id', async (req, res) => {
+  const idx = db.data.users.findIndex(u => u.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  db.data.users[idx] = { ...db.data.users[idx], ...req.body }
+  await save()
+  res.json(db.data.users[idx])
+})
+
+app.delete('/api/users/:id', async (req, res) => {
+  const idx = db.data.users.findIndex(u => u.id === Number(req.params.id))
+  if (idx === -1) return res.status(404).json({ error: 'Not found' })
+  const removed = db.data.users.splice(idx, 1)
+  await save()
+  res.json(removed[0])
+})
+
+const PORT = process.env.PORT || 3001
 app.listen(PORT, () => {
-  console.log(`Server listening on ${PORT}`);
-});
+  console.log(`Server listening on ${PORT}`)
+})


### PR DESCRIPTION
## Summary
- add lowdb with initialization helper
- persist data in `server/db.json`
- replace hardcoded data in Express server with lowdb models
- implement CRUD endpoints for teams, pairings, debates, scores, and users
- add endpoints to submit team and speaker scores and generate pairings

## Testing
- `npm run lint`
- `npm run server` (start then kill)

------
https://chatgpt.com/codex/tasks/task_e_684545bcc49883339507756f7a3f8c6c