### PR TITLE
Add score submission flow

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -73,6 +73,15 @@ app.get('/api/scores/:room', (req, res) => {
   res.json(scores[req.params.room] || []);
 });
 
+app.post('/api/scores', (req, res) => {
+  const { room, scores: roomScores } = req.body;
+  if (!room || !Array.isArray(roomScores)) {
+    return res.status(400).json({ error: 'Invalid score data' });
+  }
+  scores[room] = roomScores;
+  res.status(201).json({ status: 'ok' });
+});
+
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => {
   console.log(`Server listening on ${PORT}`);

--- a/src/components/ScoringInterface.tsx
+++ b/src/components/ScoringInterface.tsx
@@ -1,6 +1,6 @@
 
 import { useState, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,6 +30,8 @@ type SpeakerScore = {
 
 const ScoringInterface = () => {
   const [selectedDebate, setSelectedDebate] = useState('');
+  const [scoresData, setScoresData] = useState<SpeakerScore[]>([]);
+  const queryClient = useQueryClient();
 
   const fetchDebates = async () => {
     const res = await fetch('http://localhost:3001/api/debates');
@@ -51,6 +53,37 @@ const ScoringInterface = () => {
     queryFn: fetchSpeakerScores,
     enabled: !!selectedDebate
   });
+
+  useEffect(() => {
+    setScoresData(speakerScores);
+  }, [speakerScores]);
+
+  const { mutate: submitScores } = useMutation({
+    mutationFn: async (scores: SpeakerScore[]) => {
+      const res = await fetch('http://localhost:3001/api/scores', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ room: selectedDebate, scores })
+      });
+      if (!res.ok) throw new Error('Failed submitting scores');
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scores', selectedDebate] });
+      queryClient.invalidateQueries({ queryKey: ['teams'] });
+    }
+  });
+
+  const handleSubmit = () => {
+    const valid = scoresData.every(
+      (s) => s.content >= 0 && s.content <= 100 && s.style >= 0 && s.style <= 100 && s.strategy >= 0 && s.strategy <= 100
+    );
+    if (!valid) {
+      alert('Scores must be between 0 and 100');
+      return;
+    }
+    submitScores(scoresData);
+  };
 
   useEffect(() => {
     if (!selectedDebate && debates.length > 0) {
@@ -195,14 +228,14 @@ const ScoringInterface = () => {
                     <TableHead>Speaker</TableHead>
                     <TableHead>Team</TableHead>
                     <TableHead>Position</TableHead>
-                    <TableHead>Content (50-100)</TableHead>
-                    <TableHead>Style (50-100)</TableHead>
-                    <TableHead>Strategy (50-100)</TableHead>
+                    <TableHead>Content (0-100)</TableHead>
+                    <TableHead>Style (0-100)</TableHead>
+                    <TableHead>Strategy (0-100)</TableHead>
                     <TableHead>Total</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {speakerScores.map((speaker, index) => (
+                  {scoresData.map((speaker, index) => (
                     <TableRow key={index}>
                       <TableCell className="font-medium">{speaker.speaker}</TableCell>
                       <TableCell>{speaker.team}</TableCell>
@@ -210,13 +243,61 @@ const ScoringInterface = () => {
                         <Badge variant="outline">{speaker.position}</Badge>
                       </TableCell>
                       <TableCell>
-                        <Input type="number" min="50" max="100" defaultValue={speaker.content} className="w-20" />
+                        <Input
+                          type="number"
+                          min="0"
+                          max="100"
+                          value={speaker.content}
+                          onChange={(e) => {
+                            const val = Math.max(0, Math.min(100, Number(e.target.value)));
+                            const newScores = [...scoresData];
+                            newScores[index] = {
+                              ...speaker,
+                              content: val,
+                              total: val + newScores[index].style + newScores[index].strategy,
+                            };
+                            setScoresData(newScores);
+                          }}
+                          className="w-20"
+                        />
                       </TableCell>
                       <TableCell>
-                        <Input type="number" min="50" max="100" defaultValue={speaker.style} className="w-20" />
+                        <Input
+                          type="number"
+                          min="0"
+                          max="100"
+                          value={speaker.style}
+                          onChange={(e) => {
+                            const val = Math.max(0, Math.min(100, Number(e.target.value)));
+                            const newScores = [...scoresData];
+                            newScores[index] = {
+                              ...speaker,
+                              style: val,
+                              total: val + newScores[index].content + newScores[index].strategy,
+                            };
+                            setScoresData(newScores);
+                          }}
+                          className="w-20"
+                        />
                       </TableCell>
                       <TableCell>
-                        <Input type="number" min="50" max="100" defaultValue={speaker.strategy} className="w-20" />
+                        <Input
+                          type="number"
+                          min="0"
+                          max="100"
+                          value={speaker.strategy}
+                          onChange={(e) => {
+                            const val = Math.max(0, Math.min(100, Number(e.target.value)));
+                            const newScores = [...scoresData];
+                            newScores[index] = {
+                              ...speaker,
+                              strategy: val,
+                              total: val + newScores[index].content + newScores[index].style,
+                            };
+                            setScoresData(newScores);
+                          }}
+                          className="w-20"
+                        />
                       </TableCell>
                       <TableCell className="font-mono font-bold">{speaker.total}</TableCell>
                     </TableRow>
@@ -225,7 +306,7 @@ const ScoringInterface = () => {
               </Table>
               
               <div className="mt-6 flex justify-end">
-                <Button>Submit Speaker Scores</Button>
+                <Button onClick={handleSubmit}>Submit Speaker Scores</Button>
               </div>
             </TabsContent>
           </Tabs>


### PR DESCRIPTION
## Summary
- update `ScoringInterface` to handle controlled score inputs and validation
- send speaker scores to new API endpoint and refresh queries
- allow content/style/strategy scores from 0–100
- add `/api/scores` POST endpoint in the server

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684545be617083339c8ea61d3eb591ba