### PR TITLE
Add live analytics endpoints and integrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+\ntsconfig*.tsbuildinfo

--- a/server/server.js
+++ b/server/server.js
@@ -20,6 +20,7 @@ const teams = [
 const pairings = [
   {
     id: 1,
+    round: 1,
     room: 'A1',
     proposition: 'Oxford A',
     opposition: 'Cambridge B',
@@ -31,6 +32,7 @@ const pairings = [
 
 const debates = [
   {
+    round: 1,
     room: 'A1',
     proposition: 'Oxford A',
     opposition: 'Cambridge B',
@@ -71,6 +73,120 @@ app.get('/api/debates', (req, res) => {
 
 app.get('/api/scores/:room', (req, res) => {
   res.json(scores[req.params.room] || []);
+});
+
+// ----- Analytics Endpoints -----
+
+app.get('/api/analytics/standings', (req, res) => {
+  const map = new Map();
+
+  // initialize team entries
+  teams.forEach((t) => {
+    map.set(t.name, { team: t.name, wins: 0, losses: 0, speakerPoints: 0 });
+  });
+
+  // compute wins/losses from pairings
+  pairings.forEach((p) => {
+    if (p.status === 'completed') {
+      const prop = map.get(p.proposition);
+      const opp = map.get(p.opposition);
+      if (p.propWins) {
+        if (prop) prop.wins += 1;
+        if (opp) opp.losses += 1;
+      } else {
+        if (prop) prop.losses += 1;
+        if (opp) opp.wins += 1;
+      }
+    }
+  });
+
+  // add speaker points from scores
+  Object.entries(scores).forEach(([room, speakerScores]) => {
+    speakerScores.forEach((s) => {
+      const team = map.get(s.team);
+      if (team) team.speakerPoints += s.total;
+    });
+  });
+
+  const standings = Array.from(map.values()).map((t) => ({
+    ...t,
+    points: t.wins * 3,
+  }));
+
+  standings.sort((a, b) => {
+    if (b.points !== a.points) return b.points - a.points;
+    return b.speakerPoints - a.speakerPoints;
+  });
+
+  standings.forEach((s, idx) => {
+    s.rank = idx + 1;
+  });
+
+  res.json(standings);
+});
+
+app.get('/api/analytics/speakers', (req, res) => {
+  const map = new Map();
+
+  Object.values(scores).forEach((roomScores) => {
+    roomScores.forEach((s) => {
+      if (!map.has(s.speaker)) {
+        map.set(s.speaker, { name: s.speaker, team: s.team, total: 0, count: 0 });
+      }
+      const entry = map.get(s.speaker);
+      entry.total += s.total;
+      entry.count += 1;
+    });
+  });
+
+  const speakers = Array.from(map.values()).map((s) => ({
+    ...s,
+    average: s.count ? s.total / s.count : 0,
+  }));
+
+  speakers.sort((a, b) => b.average - a.average);
+  speakers.forEach((s, idx) => (s.rank = idx + 1));
+
+  res.json(speakers);
+});
+
+app.get('/api/analytics/performance', (req, res) => {
+  const rounds = new Map();
+
+  Object.entries(scores).forEach(([room, speakerScores]) => {
+    const pairing = pairings.find((p) => p.room === room);
+    const round = pairing ? pairing.round : 1;
+    if (!rounds.has(round)) rounds.set(round, { round, total: 0, debates: 0 });
+    const entry = rounds.get(round);
+    const debateAvg =
+      speakerScores.reduce((acc, s) => acc + s.total, 0) / speakerScores.length;
+    entry.total += debateAvg;
+    entry.debates += 1;
+  });
+
+  const performance = Array.from(rounds.values()).map((r) => ({
+    round: `R${r.round}`,
+    avgScore: r.debates ? r.total / r.debates : 0,
+    debates: r.debates,
+  }));
+
+  performance.sort((a, b) => parseInt(a.round.slice(1)) - parseInt(b.round.slice(1)));
+
+  res.json(performance);
+});
+
+app.get('/api/analytics/results', (req, res) => {
+  let propWins = 0;
+  let oppWins = 0;
+  let ties = 0;
+  pairings.forEach((p) => {
+    if (p.status === 'completed') {
+      if (p.propWins === true) propWins += 1;
+      else if (p.propWins === false) oppWins += 1;
+      else ties += 1;
+    }
+  });
+  res.json({ propWins, oppWins, ties });
 });
 
 const PORT = process.env.PORT || 3001;


### PR DESCRIPTION
## Summary
- compute team standings, speaker rankings, round performance and result distribution on the server
- fetch analytics via React Query in `LiveAnalytics`
- hook dashboard quick stats to analytics
- ignore TypeScript build info files

## Testing
- `npm run lint`
- `npm run build`
- `npx tsc -b`


------
https://chatgpt.com/codex/tasks/task_e_684545bf60108333bb9ec3918c9d0a7b