### PR TITLE
Add API fetch utility and environment config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Base URL for the API server
+VITE_API_BASE_URL=http://localhost:3001

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/src/components/PairingEngine.tsx
+++ b/src/components/PairingEngine.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Shuffle, Play, Clock, MapPin, CheckCircle } from 'lucide-react';
+import { apiFetch } from "@/lib/api";
 
 type Pairing = {
   id: number;
@@ -23,7 +24,7 @@ const PairingEngine = () => {
   const [currentRound, setCurrentRound] = useState(3);
   
   const fetchPairings = async () => {
-    const res = await fetch('http://localhost:3001/api/pairings');
+    const res = await apiFetch('/api/pairings');
     if (!res.ok) throw new Error('Failed fetching pairings');
     return res.json();
   };
@@ -44,7 +45,7 @@ const PairingEngine = () => {
   };
 
   const generatePairings = async () => {
-    await fetch('http://localhost:3001/api/pairings/generate', {
+    await apiFetch('/api/pairings/generate', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ algorithm: pairingAlgorithm, round: currentRound })

--- a/src/components/ScoringInterface.tsx
+++ b/src/components/ScoringInterface.tsx
@@ -9,6 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Target, Trophy, User, Clock } from 'lucide-react';
+import { apiFetch } from "@/lib/api";
 
 type Debate = {
   room: string;
@@ -32,7 +33,7 @@ const ScoringInterface = () => {
   const [selectedDebate, setSelectedDebate] = useState('');
 
   const fetchDebates = async () => {
-    const res = await fetch('http://localhost:3001/api/debates');
+    const res = await apiFetch('/api/debates');
     if (!res.ok) throw new Error('Failed fetching debates');
     return res.json();
   };
@@ -41,7 +42,7 @@ const ScoringInterface = () => {
 
   const fetchSpeakerScores = async () => {
     if (!selectedDebate) return [];
-    const res = await fetch(`http://localhost:3001/api/scores/${selectedDebate}`);
+    const res = await apiFetch(`/api/scores/${selectedDebate}`);
     if (!res.ok) throw new Error('Failed fetching scores');
     return res.json();
   };

--- a/src/components/TeamRoster.tsx
+++ b/src/components/TeamRoster.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Plus, Upload, Download, Search, Edit, Trash2 } from 'lucide-react';
+import { apiFetch } from "@/lib/api";
 
 type Team = {
   id: number;
@@ -30,7 +31,7 @@ const TeamRoster = () => {
   const queryClient = useQueryClient();
 
   const fetchTeams = async () => {
-    const res = await fetch('http://localhost:3001/api/teams');
+    const res = await apiFetch('/api/teams');
     if (!res.ok) throw new Error('Failed fetching teams');
     return res.json();
   };
@@ -38,7 +39,7 @@ const TeamRoster = () => {
   const { data: teams = [] } = useQuery<Team[]>({ queryKey: ['teams'], queryFn: fetchTeams });
 
   const addTeam = async () => {
-    const res = await fetch('http://localhost:3001/api/teams', {
+    const res = await apiFetch('/api/teams', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,6 @@
+export const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || '';
+
+export function apiFetch(input: string, init?: RequestInit) {
+  const url = input.startsWith('http') ? input : `${apiBaseUrl}${input}`;
+  return fetch(url, init);
+}


### PR DESCRIPTION
## Summary
- centralize API requests through `apiFetch`
- read API base URL from `VITE_API_BASE_URL`
- use the new helper in TeamRoster, PairingEngine and ScoringInterface
- add `.env.example` and ignore `.env`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684545c0b9c4833399b20c66629689cd