### PR TITLE
Update README with API server notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,16 @@ npm run preview
 npm run lint
 ```
 
+### Local API Server
+
+Run the mock API with:
+
+```bash
+npm run server
+```
+
+By default it listens on `http://localhost:3001` unless the `PORT` environment variable is set. The frontend expects the server URL to match `VITE_API_BASE_URL`.
+
 ## 🎯 Success Criteria
 
 The platform aims to enable tournament administrators to:


### PR DESCRIPTION
## Summary
- document `npm run server`
- explain that the frontend expects `VITE_API_BASE_URL` to match the API URL

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68454a471d2c83339771f4ec6b668829