### PR TITLE
Add Jest + RTL setup with unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.app.json',
+      useESM: true
+    }
+  }
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,12 @@
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+
+// Polyfill TextEncoder/TextDecoder for testing environment
+if (!global.TextEncoder) {
+  // @ts-ignore
+  global.TextEncoder = TextEncoder;
+}
+if (!global.TextDecoder) {
+  // @ts-ignore
+  global.TextDecoder = TextDecoder;
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "server": "node server/server.js"
+    "server": "node --loader ts-node/esm server/server.ts",
+    "test": "bun x jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -67,6 +68,10 @@
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@tailwindcss/typography": "^0.5.15",
+    "@testing-library/jest-dom": "6.4.2",
+    "@testing-library/react": "14.2.2",
+    "@testing-library/user-event": "14.4.3",
+    "@types/jest": "29.5.12",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
@@ -76,9 +81,14 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.9",
     "globals": "^15.9.0",
+    "jest": "29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "lovable-tagger": "^1.1.7",
     "postcss": "^8.4.47",
+    "supertest": "6.3.3",
     "tailwindcss": "^3.4.11",
+    "ts-jest": "29.1.2",
+    "ts-node": "^10.9.2",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"

--- a/server/__tests__/server.test.ts
+++ b/server/__tests__/server.test.ts
@@ -1,0 +1,37 @@
+/** @jest-environment node */
+import request from 'supertest';
+
+let app: any;
+
+beforeAll(async () => {
+  const mod = await import('../server.ts');
+  app = mod.default;
+});
+
+describe('API Endpoints', () => {
+  it('GET /api/teams should return teams', async () => {
+    const res = await request(app).get('/api/teams');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty('name');
+  });
+
+  it('POST /api/teams should create a team', async () => {
+    const team = { name: 'Test Team', organization: 'Test Org', speakers: ['A', 'B'] };
+    const res = await request(app).post('/api/teams').send(team);
+    expect(res.status).toBe(201);
+    expect(res.body.name).toBe(team.name);
+  });
+
+  it('GET /api/pairings should return pairings', async () => {
+    const res = await request(app).get('/api/pairings');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('GET /api/scores/:room should return scores', async () => {
+    const res = await request(app).get('/api/scores/A1');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,83 @@
+import express from 'express';
+import cors from 'cors';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const teams = [
+  {
+    id: 1,
+    name: 'Oxford A',
+    organization: 'Oxford University',
+    speakers: ['Alice Johnson', 'Bob Smith'],
+    wins: 0,
+    losses: 0,
+    speakerPoints: 0,
+  }
+];
+
+const pairings = [
+  {
+    id: 1,
+    room: 'A1',
+    proposition: 'Oxford A',
+    opposition: 'Cambridge B',
+    judge: 'Dr. Sarah Wilson',
+    status: 'completed',
+    propWins: true,
+  }
+];
+
+const debates = [
+  {
+    room: 'A1',
+    proposition: 'Oxford A',
+    opposition: 'Cambridge B',
+    judge: 'Dr. Sarah Wilson',
+    status: 'scoring',
+  }
+];
+
+const scores = {
+  A1: [
+    { speaker: 'Alice Johnson', team: 'Oxford A', position: 'PM', content: 78, style: 82, strategy: 80, total: 240 },
+    { speaker: 'Bob Smith', team: 'Oxford A', position: 'DPM', content: 75, style: 79, strategy: 77, total: 231 },
+  ]
+};
+
+app.get('/api/teams', (req, res) => {
+  res.json(teams);
+});
+
+app.post('/api/teams', (req, res) => {
+  const team = { id: teams.length + 1, wins: 0, losses: 0, speakerPoints: 0, ...req.body };
+  teams.push(team);
+  res.status(201).json(team);
+});
+
+app.get('/api/pairings', (req, res) => {
+  res.json(pairings);
+});
+
+app.post('/api/pairings/generate', (req, res) => {
+  // placeholder generation logic
+  res.json({ status: 'ok' });
+});
+
+app.get('/api/debates', (req, res) => {
+  res.json(debates);
+});
+
+app.get('/api/scores/:room', (req, res) => {
+  res.json(scores[req.params.room] || []);
+});
+
+const PORT = process.env.PORT || 3001;
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`Server listening on ${PORT}`);
+  });
+}
+
+export default app;

--- a/server/server.ts
+++ b/server/server.ts
@@ -74,6 +74,10 @@ app.get('/api/scores/:room', (req, res) => {
 });
 
 const PORT = process.env.PORT || 3001;
-app.listen(PORT, () => {
-  console.log(`Server listening on ${PORT}`);
-});
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`Server listening on ${PORT}`);
+  });
+}
+
+export default app;

--- a/src/components/__tests__/PairingEngine.test.tsx
+++ b/src/components/__tests__/PairingEngine.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import PairingEngine from '../PairingEngine';
+
+const mockPairings = [
+  { id: 1, room: 'A1', proposition: 'Team A', opposition: 'Team B', judge: 'Judge', status: 'completed', propWins: true }
+];
+
+global.fetch = jest.fn(() => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve(mockPairings)
+})) as jest.Mock;
+
+const renderComponent = () => {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <PairingEngine />
+    </QueryClientProvider>
+  );
+};
+
+describe('PairingEngine', () => {
+  it('renders pairings from API', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Team A')).toBeInTheDocument();
+      expect(screen.getByText('Team B')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/TeamRoster.test.tsx
+++ b/src/components/__tests__/TeamRoster.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import TeamRoster from '../TeamRoster';
+
+const mockTeams = [
+  { id: 1, name: 'Alpha', organization: 'Org', speakers: [], wins: 0, losses: 0, speakerPoints: 0 }
+];
+
+global.fetch = jest.fn(() => Promise.resolve({
+  ok: true,
+  json: () => Promise.resolve(mockTeams)
+})) as jest.Mock;
+
+const renderComponent = () => {
+  const client = new QueryClient();
+  return render(
+    <QueryClientProvider client={client}>
+      <TeamRoster />
+    </QueryClientProvider>
+  );
+};
+
+describe('TeamRoster', () => {
+  it('displays teams from API', async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText('Alpha')).toBeInTheDocument();
+    });
+  });
+});

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,6 +20,7 @@
     "noUnusedParameters": false,
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": false,
+    "esModuleInterop": true,
 
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -18,5 +18,5 @@
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "server/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- configure Jest using ts-jest and add a setup file
- export the Express app for testing and guard against starting the server during tests
- add React Testing Library component tests and Supertest endpoint tests
- update package scripts and dev dependencies
- include server files in Node tsconfig
- revert bun.lockb to avoid binary diffs

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684545c231388333aab0f516b8b45dc8