### PR TITLE
Use apiFetch for API base URL

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+server/server.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 
 export default tseslint.config(
-  { ignores: ["dist"] },
+  { ignores: ["dist", "server/server.js"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/*.{ts,tsx}"],

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ export default {
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   globals: {
     'ts-jest': {
-      tsconfig: 'tsconfig.app.json',
+      tsconfig: '<rootDir>/tsconfig.test.json',
       useESM: true
     }
   }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -3,10 +3,10 @@ import { TextEncoder, TextDecoder } from 'util';
 
 // Polyfill TextEncoder/TextDecoder for testing environment
 if (!global.TextEncoder) {
-  // @ts-ignore
-  global.TextEncoder = TextEncoder;
+  (global as unknown as { TextEncoder: typeof TextEncoder }).TextEncoder =
+    TextEncoder;
 }
 if (!global.TextDecoder) {
-  // @ts-ignore
-  global.TextDecoder = TextDecoder;
+  (global as unknown as { TextDecoder: typeof TextDecoder }).TextDecoder =
+    TextDecoder;
 }

--- a/server/__tests__/server.test.ts
+++ b/server/__tests__/server.test.ts
@@ -1,7 +1,8 @@
 /** @jest-environment node */
 import request from 'supertest';
+import type { Express } from 'express';
 
-let app: any;
+let app: Express;
 
 beforeAll(async () => {
   const mod = await import('../server.ts');

--- a/src/components/LiveAnalytics.tsx
+++ b/src/components/LiveAnalytics.tsx
@@ -5,28 +5,29 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line, PieChart, Pie, Cell } from 'recharts';
 import { Trophy, TrendingUp, Users, Target } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
 
 const LiveAnalytics = () => {
   const fetchStandings = async () => {
-    const res = await fetch('http://localhost:3001/api/analytics/standings');
+    const res = await apiFetch('/api/analytics/standings');
     if (!res.ok) throw new Error('Failed fetching standings');
     return res.json();
   };
 
   const fetchSpeakers = async () => {
-    const res = await fetch('http://localhost:3001/api/analytics/speakers');
+    const res = await apiFetch('/api/analytics/speakers');
     if (!res.ok) throw new Error('Failed fetching speakers');
     return res.json();
   };
 
   const fetchPerformance = async () => {
-    const res = await fetch('http://localhost:3001/api/analytics/performance');
+    const res = await apiFetch('/api/analytics/performance');
     if (!res.ok) throw new Error('Failed fetching performance');
     return res.json();
   };
 
   const fetchResults = async () => {
-    const res = await fetch('http://localhost:3001/api/analytics/results');
+    const res = await apiFetch('/api/analytics/results');
     if (!res.ok) throw new Error('Failed fetching results');
     return res.json();
   };

--- a/src/components/PairingEngine.tsx
+++ b/src/components/PairingEngine.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import apiFetch from '../utils/apiFetch';
+import { apiFetch } from '@/lib/api';
 
 type Pairing = {
   id: number;
@@ -46,7 +46,9 @@ const PairingEngine: React.FC = () => {
       <h2>Round {currentRound}</h2>
       <select
         value={pairingAlgorithm}
-        onChange={e => setPairingAlgorithm(e.target.value as any)}
+        onChange={e =>
+          setPairingAlgorithm(e.target.value as 'swiss' | 'power' | 'random')
+        }
       >
         <option value="swiss">Swiss</option>
         <option value="power">Power</option>

--- a/src/components/ScoringInterface.tsx
+++ b/src/components/ScoringInterface.tsx
@@ -61,7 +61,7 @@ const ScoringInterface = () => {
 
   const { mutate: submitScores } = useMutation({
     mutationFn: async (scores: SpeakerScore[]) => {
-      const res = await fetch('http://localhost:3001/api/scores', {
+      const res = await apiFetch('/api/scores', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ room: selectedDebate, scores })

--- a/src/components/TeamRoster.tsx
+++ b/src/components/TeamRoster.tsx
@@ -60,7 +60,7 @@ const TeamRoster = () => {
   });
 
   const updateTeam = async (payload: { id: number; updates: Partial<Team> }) => {
-    const res = await fetch(`http://localhost:3001/api/teams/${payload.id}`, {
+    const res = await apiFetch(`/api/teams/${payload.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload.updates)
@@ -70,7 +70,7 @@ const TeamRoster = () => {
   };
 
   const deleteTeam = async (id: number) => {
-    const res = await fetch(`http://localhost:3001/api/teams/${id}`, {
+    const res = await apiFetch(`/api/teams/${id}`, {
       method: 'DELETE'
     });
     if (!res.ok) throw new Error('Failed to delete team');

--- a/src/components/TournamentManagement.tsx
+++ b/src/components/TournamentManagement.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Users, Trophy, Play, Pause, TrendingUp, Target } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from '@/lib/api';
 
 interface TournamentManagementProps {
   activeTournament: {
@@ -22,13 +23,13 @@ const TournamentManagement = ({ activeTournament }: TournamentManagementProps) =
   const progress = (currentRound / totalRounds) * 100;
 
   const fetchStandings = async () => {
-    const res = await fetch('http://localhost:3001/api/analytics/standings');
+    const res = await apiFetch('/api/analytics/standings');
     if (!res.ok) throw new Error('Failed fetching standings');
     return res.json();
   };
 
   const fetchPerformance = async () => {
-    const res = await fetch('http://localhost:3001/api/analytics/performance');
+    const res = await apiFetch('/api/analytics/performance');
     if (!res.ok) throw new Error('Failed fetching performance');
     return res.json();
   };

--- a/src/components/UserRoleManager.tsx
+++ b/src/components/UserRoleManager.tsx
@@ -9,6 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Plus, Edit, Trash2, Shield, Users, Eye } from 'lucide-react';
+import { apiFetch } from '@/lib/api';
 
 type User = {
   id: number;
@@ -36,7 +37,7 @@ const UserRoleManager = ({ currentUser }: UserRoleManagerProps) => {
   const queryClient = useQueryClient();
 
   const fetchUsers = async () => {
-    const res = await fetch('http://localhost:3001/api/users');
+    const res = await apiFetch('/api/users');
     if (!res.ok) throw new Error('Failed fetching users');
     return res.json();
   };
@@ -44,7 +45,7 @@ const UserRoleManager = ({ currentUser }: UserRoleManagerProps) => {
   const { data: users = [] } = useQuery<User[]>({ queryKey: ['users'], queryFn: fetchUsers });
 
   const addUser = async () => {
-    const res = await fetch('http://localhost:3001/api/users', {
+    const res = await apiFetch('/api/users', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name, email, role, lastActive: 'just now', status: 'active', permissions: [] })
@@ -54,7 +55,7 @@ const UserRoleManager = ({ currentUser }: UserRoleManagerProps) => {
   };
 
   const updateUser = async (user: User) => {
-    const res = await fetch(`http://localhost:3001/api/users/${user.id}`, {
+    const res = await apiFetch(`/api/users/${user.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(user)
@@ -64,7 +65,7 @@ const UserRoleManager = ({ currentUser }: UserRoleManagerProps) => {
   };
 
   const deleteUser = async (id: number) => {
-    const res = await fetch(`http://localhost:3001/api/users/${id}`, { method: 'DELETE' });
+    const res = await apiFetch(`/api/users/${id}`, { method: 'DELETE' });
     if (!res.ok) throw new Error('Failed to delete user');
     return res.json();
   };

--- a/src/components/__tests__/PairingEngine.test.tsx
+++ b/src/components/__tests__/PairingEngine.test.tsx
@@ -6,9 +6,14 @@ const mockPairings = [
   { id: 1, room: 'A1', proposition: 'Team A', opposition: 'Team B', judge: 'Judge', status: 'completed', propWins: true }
 ];
 
+const mockResponse = {
+  pairings: mockPairings,
+  currentRound: 1
+};
+
 global.fetch = jest.fn(() => Promise.resolve({
   ok: true,
-  json: () => Promise.resolve(mockPairings)
+  json: () => Promise.resolve(mockResponse)
 })) as jest.Mock;
 
 const renderComponent = () => {
@@ -24,8 +29,8 @@ describe('PairingEngine', () => {
   it('renders pairings from API', async () => {
     renderComponent();
     await waitFor(() => {
-      expect(screen.getByText('Team A')).toBeInTheDocument();
-      expect(screen.getByText('Team B')).toBeInTheDocument();
+      expect(screen.getByText(/Team A/)).toBeInTheDocument();
+      expect(screen.getByText(/Team B/)).toBeInTheDocument();
     });
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-export const apiBaseUrl = import.meta.env.VITE_API_BASE_URL || '';
+export const apiBaseUrl = process.env.VITE_API_BASE_URL || '';
 
 export function apiFetch(input: string, init?: RequestInit) {
   const url = input.startsWith('http') ? input : `${apiBaseUrl}${input}`;

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "node",
+    "target": "ES2022",
+    "types": ["jest", "@testing-library/jest-dom", "node"],
+    "esModuleInterop": true
+  },
+  "include": ["src", "server"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,11 @@ export default defineConfig(({ mode }) => ({
     mode === 'development' &&
     componentTagger(),
   ].filter(Boolean),
+  define: {
+    'process.env': {
+      VITE_API_BASE_URL: process.env.VITE_API_BASE_URL
+    }
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- use `apiFetch` for all API requests so base URL respects `VITE_API_BASE_URL`
- configure test TypeScript settings
- ignore compiled server file from ESLint
- fix React Query tests and polyfills for TextEncoder/Decoder

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68454fdf4dc0833396cd5b857c05cf2e