### PR TITLE
Add polling for debates and scores

### DIFF
--- a/src/components/ScoringInterface.tsx
+++ b/src/components/ScoringInterface.tsx
@@ -40,7 +40,12 @@ const ScoringInterface = () => {
     return res.json();
   };
 
-  const { data: debates = [] } = useQuery<Debate[]>({ queryKey: ['debates'], queryFn: fetchDebates });
+  const { data: debates = [] } = useQuery<Debate[]>({
+    queryKey: ['debates'],
+    queryFn: fetchDebates,
+    // Poll periodically so judges get the latest available debates
+    refetchInterval: 5000
+  });
 
   const fetchSpeakerScores = async () => {
     if (!selectedDebate) return [];
@@ -52,7 +57,9 @@ const ScoringInterface = () => {
   const { data: speakerScores = [] } = useQuery<SpeakerScore[]>({
     queryKey: ['scores', selectedDebate],
     queryFn: fetchSpeakerScores,
-    enabled: !!selectedDebate
+    enabled: !!selectedDebate,
+    // Keep scores in sync while judges input data
+    refetchInterval: 5000
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- poll debates and speaker scores to keep scoring interface fresh

## Testing
- `npm test` *(fails: Preset ts-jest/presets/default-esm not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68454fe1004c83339d53c6f1251d0686