### PR TITLE
Add user API tests and endpoints

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -161,6 +161,40 @@ app.post('/api/scores', async (req, res) => {
   res.status(201).json(entry);
 });
 
+// ─── Users CRUD ────────────────────────────────────────────────────────────
+app.get('/api/users', async (_req, res) => {
+  await db.read();
+  res.json(db.data.users);
+});
+
+app.post('/api/users', async (req, res) => {
+  await db.read();
+  const user = { id: Date.now(), ...req.body };
+  db.data.users.push(user);
+  await save();
+  res.status(201).json(user);
+});
+
+app.put('/api/users/:id', async (req, res) => {
+  await db.read();
+  const id = Number(req.params.id);
+  const idx = db.data.users.findIndex(u => u.id === id);
+  if (idx === -1) return res.status(404).json({ error: 'Not found' });
+  db.data.users[idx] = { ...db.data.users[idx], ...req.body };
+  await save();
+  res.json(db.data.users[idx]);
+});
+
+app.delete('/api/users/:id', async (req, res) => {
+  await db.read();
+  const id = Number(req.params.id);
+  const idx = db.data.users.findIndex(u => u.id === id);
+  if (idx === -1) return res.status(404).json({ error: 'Not found' });
+  const [removed] = db.data.users.splice(idx, 1);
+  await save();
+  res.json(removed);
+});
+
 // ─── Analytics Endpoints ───────────────────────────────────────────────────
 
 // Standings


### PR DESCRIPTION
## Summary
- ensure server.db resets between tests and add user endpoint tests
- implement CRUD routes for `/api/users`

## Testing
- `npm test` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458068804c83339a3e44a071683833