### PR TITLE
Restore fs-based database and user routes

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -1,99 +1,129 @@
 import express from 'express';
 import cors from 'cors';
-import db, { initDB } from './db';
-
-// Initialize DB (create file and defaults if needed)
-initDB();
+import { promises as fs } from 'fs';
+import path from 'path';
 
 const app = express();
 app.use(cors());
 app.use(express.json());
 
-// Helper to persist LowDB changes
-const save = () => db.write();
+// Path to JSON database
+const DB_FILE = path.join(process.cwd(), 'server', 'db.json');
+
+export interface Database {
+  teams: any[];
+  pairings: any[];
+  debates: any[];
+  scores: any[];
+  users: any[];
+  currentRound: number;
+}
+
+const defaultData: Database = {
+  teams: [],
+  pairings: [],
+  debates: [],
+  scores: [],
+  users: [],
+  currentRound: 1,
+};
+
+async function readDb(): Promise<Database> {
+  try {
+    const text = await fs.readFile(DB_FILE, 'utf8');
+    return { ...defaultData, ...JSON.parse(text) } as Database;
+  } catch {
+    await fs.writeFile(DB_FILE, JSON.stringify(defaultData, null, 2));
+    return { ...defaultData };
+  }
+}
+
+async function writeDb(data: Database) {
+  await fs.writeFile(DB_FILE, JSON.stringify(data, null, 2));
+}
 
 // ─── Teams CRUD ────────────────────────────────────────────────────────────
 app.get('/api/teams', async (_req, res) => {
-  await db.read();
-  res.json(db.data.teams);
+  const data = await readDb();
+  res.json(data.teams);
 });
 
 app.get('/api/teams/:id', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const id = Number(req.params.id);
-  const team = db.data.teams.find(t => t.id === id);
+  const team = data.teams.find(t => t.id === id);
   if (!team) return res.status(404).json({ error: 'Not found' });
   res.json(team);
 });
 
 app.post('/api/teams', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const nextId = Date.now();
   const team = { id: nextId, wins: 0, losses: 0, speakerPoints: 0, ...req.body };
-  db.data.teams.push(team);
-  await save();
+  data.teams.push(team);
+  await writeDb(data);
   res.status(201).json(team);
 });
 
 app.put('/api/teams/:id', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const id = Number(req.params.id);
-  const idx = db.data.teams.findIndex(t => t.id === id);
+  const idx = data.teams.findIndex(t => t.id === id);
   if (idx === -1) return res.status(404).json({ error: 'Not found' });
-  db.data.teams[idx] = { ...db.data.teams[idx], ...req.body };
-  await save();
-  res.json(db.data.teams[idx]);
+  data.teams[idx] = { ...data.teams[idx], ...req.body };
+  await writeDb(data);
+  res.json(data.teams[idx]);
 });
 
 app.delete('/api/teams/:id', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const id = Number(req.params.id);
-  const idx = db.data.teams.findIndex(t => t.id === id);
+  const idx = data.teams.findIndex(t => t.id === id);
   if (idx === -1) return res.status(404).json({ error: 'Not found' });
-  const [removed] = db.data.teams.splice(idx, 1);
-  await save();
+  const [removed] = data.teams.splice(idx, 1);
+  await writeDb(data);
   res.json(removed);
 });
 
 // ─── Pairings CRUD ─────────────────────────────────────────────────────────
 app.get('/api/pairings', async (_req, res) => {
-  await db.read();
-  res.json({ pairings: db.data.pairings, currentRound: db.data.currentRound });
+  const data = await readDb();
+  res.json({ pairings: data.pairings, currentRound: data.currentRound });
 });
 
 app.get('/api/pairings/:id', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const id = Number(req.params.id);
-  const pairing = db.data.pairings.find(p => p.id === id);
+  const pairing = data.pairings.find(p => p.id === id);
   if (!pairing) return res.status(404).json({ error: 'Not found' });
   res.json(pairing);
 });
 
 app.post('/api/pairings', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const pairing = { id: Date.now(), ...req.body };
-  db.data.pairings.push(pairing);
-  await save();
+  data.pairings.push(pairing);
+  await writeDb(data);
   res.status(201).json(pairing);
 });
 
 app.put('/api/pairings/:id', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const id = Number(req.params.id);
-  const idx = db.data.pairings.findIndex(p => p.id === id);
+  const idx = data.pairings.findIndex(p => p.id === id);
   if (idx === -1) return res.status(404).json({ error: 'Not found' });
-  db.data.pairings[idx] = { ...db.data.pairings[idx], ...req.body };
-  await save();
-  res.json(db.data.pairings[idx]);
+  data.pairings[idx] = { ...data.pairings[idx], ...req.body };
+  await writeDb(data);
+  res.json(data.pairings[idx]);
 });
 
 app.delete('/api/pairings/:id', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const id = Number(req.params.id);
-  const idx = db.data.pairings.findIndex(p => p.id === id);
+  const idx = data.pairings.findIndex(p => p.id === id);
   if (idx === -1) return res.status(404).json({ error: 'Not found' });
-  const [removed] = db.data.pairings.splice(idx, 1);
-  await save();
+  const [removed] = data.pairings.splice(idx, 1);
+  await writeDb(data);
   res.json(removed);
 });
 
@@ -105,68 +135,109 @@ app.post('/api/pairings/generate', async (_req, res) => {
 
 // ─── Debates CRUD ──────────────────────────────────────────────────────────
 app.get('/api/debates', async (_req, res) => {
-  await db.read();
-  res.json(db.data.debates);
+  const data = await readDb();
+  res.json(data.debates);
 });
 
 app.get('/api/debates/:id', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const id = Number(req.params.id);
-  const debate = db.data.debates.find(d => d.id === id);
+  const debate = data.debates.find(d => d.id === id);
   if (!debate) return res.status(404).json({ error: 'Not found' });
   res.json(debate);
 });
 
 app.post('/api/debates', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const debate = { id: Date.now(), ...req.body };
-  db.data.debates.push(debate);
-  await save();
+  data.debates.push(debate);
+  await writeDb(data);
   res.status(201).json(debate);
 });
 
 app.put('/api/debates/:id', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const id = Number(req.params.id);
-  const idx = db.data.debates.findIndex(d => d.id === id);
+  const idx = data.debates.findIndex(d => d.id === id);
   if (idx === -1) return res.status(404).json({ error: 'Not found' });
-  db.data.debates[idx] = { ...db.data.debates[idx], ...req.body };
-  await save();
-  res.json(db.data.debates[idx]);
+  data.debates[idx] = { ...data.debates[idx], ...req.body };
+  await writeDb(data);
+  res.json(data.debates[idx]);
 });
 
 app.delete('/api/debates/:id', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const id = Number(req.params.id);
-  const idx = db.data.debates.findIndex(d => d.id === id);
+  const idx = data.debates.findIndex(d => d.id === id);
   if (idx === -1) return res.status(404).json({ error: 'Not found' });
-  const [removed] = db.data.debates.splice(idx, 1);
-  await save();
+  const [removed] = data.debates.splice(idx, 1);
+  await writeDb(data);
   res.json(removed);
 });
 
 // ─── Scores CRUD ───────────────────────────────────────────────────────────
 app.get('/api/scores/:room', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const room = req.params.room;
-  const result = db.data.scores.filter(s => s.room === room);
+  const result = data.scores.filter(s => s.room === room);
   res.json(result);
 });
 
 app.post('/api/scores', async (req, res) => {
-  await db.read();
+  const data = await readDb();
   const entry = { id: Date.now(), ...req.body };
-  db.data.scores.push(entry);
-  await save();
+  data.scores.push(entry);
+  await writeDb(data);
   res.status(201).json(entry);
+});
+
+// ─── Users CRUD ────────────────────────────────────────────────────────────
+app.get('/api/users', async (_req, res) => {
+  const data = await readDb();
+  res.json(data.users);
+});
+
+app.get('/api/users/:id', async (req, res) => {
+  const data = await readDb();
+  const id = Number(req.params.id);
+  const user = data.users.find(u => u.id === id);
+  if (!user) return res.status(404).json({ error: 'Not found' });
+  res.json(user);
+});
+
+app.post('/api/users', async (req, res) => {
+  const data = await readDb();
+  const user = { id: Date.now(), ...req.body };
+  data.users.push(user);
+  await writeDb(data);
+  res.status(201).json(user);
+});
+
+app.put('/api/users/:id', async (req, res) => {
+  const data = await readDb();
+  const id = Number(req.params.id);
+  const idx = data.users.findIndex(u => u.id === id);
+  if (idx === -1) return res.status(404).json({ error: 'Not found' });
+  data.users[idx] = { ...data.users[idx], ...req.body };
+  await writeDb(data);
+  res.json(data.users[idx]);
+});
+
+app.delete('/api/users/:id', async (req, res) => {
+  const data = await readDb();
+  const id = Number(req.params.id);
+  const idx = data.users.findIndex(u => u.id === id);
+  if (idx === -1) return res.status(404).json({ error: 'Not found' });
+  const [removed] = data.users.splice(idx, 1);
+  await writeDb(data);
+  res.json(removed);
 });
 
 // ─── Analytics Endpoints ───────────────────────────────────────────────────
 
 // Standings
 app.get('/api/analytics/standings', async (_req, res) => {
-  await db.read();
-  const { teams, pairings, scores } = db.data;
+  const { teams, pairings, scores } = await readDb();
   const map = new Map<string, { team: string; wins: number; losses: number; speakerPoints: number }>();
   teams.forEach(t => map.set(t.name, { team: t.name, wins: 0, losses: 0, speakerPoints: 0 }));
   pairings.forEach(p => {
@@ -190,8 +261,7 @@ app.get('/api/analytics/standings', async (_req, res) => {
 
 // Speaker averages
 app.get('/api/analytics/speakers', async (_req, res) => {
-  await db.read();
-  const { scores } = db.data;
+  const { scores } = await readDb();
   const map = new Map<string, { name: string; team: string; total: number; count: number }>();
   scores.forEach(s => {
     if (!map.has(s.speaker)) map.set(s.speaker, { name: s.speaker, team: s.team, total: 0, count: 0 });
@@ -208,8 +278,7 @@ app.get('/api/analytics/speakers', async (_req, res) => {
 
 // Round performance
 app.get('/api/analytics/performance', async (_req, res) => {
-  await db.read();
-  const { pairings, scores } = db.data;
+  const { pairings, scores } = await readDb();
   const rounds = new Map<number, { round: number; total: number; debates: number }>();
   scores.forEach(s => {
     const p = pairings.find(p => p.room === s.room);
@@ -227,8 +296,7 @@ app.get('/api/analytics/performance', async (_req, res) => {
 
 // Summary
 app.get('/api/analytics/results', async (_req, res) => {
-  await db.read();
-  const { pairings } = db.data;
+  const { pairings } = await readDb();
   let propWins = 0, oppWins = 0, ties = 0;
   pairings.forEach(p => {
     if (p.status === 'completed') {


### PR DESCRIPTION
## Summary
- reimplement server db helpers using `fs`
- persist all API changes by reading/writing `db.json`
- restore `/api/users` CRUD routes
- keep existing team, pairing, debate and score endpoints
- start server only outside tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68458068a7b48333b859985bec9450ed