### PR TITLE
Handle invalid speaker counts in team creation

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,5 @@
 // jest.config.js
-export default {
+module.exports = {
   preset: 'ts-jest/presets/default-esm',
   // Most tests (components) run in a jsdom environment; server tests can override as needed
   testEnvironment: 'jsdom',

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
-import { JSDOM } from 'jsdom';
 
 // Polyfill TextEncoder/TextDecoder for the test environment
 if (typeof global.TextEncoder === 'undefined') {
@@ -11,6 +10,8 @@ if (typeof global.TextDecoder === 'undefined') {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (global as any).TextDecoder = TextDecoder;
 }
+
+import { JSDOM } from 'jsdom';
 
 // Basic DOM polyfill for the test runner
 if (typeof document === 'undefined') {

--- a/src/components/TeamRoster.tsx
+++ b/src/components/TeamRoster.tsx
@@ -237,15 +237,25 @@ const TeamRoster = () => {
                 <Button
                   className="w-full"
                   onClick={async () => {
-                    if (speakers.filter(Boolean).length > 5) {
+                    const validSpeakers = speakers.filter(Boolean);
+                    if (validSpeakers.length < 1) {
+                      alert('Team must have at least one speaker');
+                      return;
+                    }
+                    if (validSpeakers.length > 5) {
                       alert('Cannot add more than 5 speakers');
                       return;
                     }
-                    await createTeam();
-                    setTeamName('');
-                    setOrganization('');
-                    setSpeakers(['', '']);
-                    setOpen(false);
+                    try {
+                      await createTeam();
+                      setTeamName('');
+                      setOrganization('');
+                      setSpeakers(['', '']);
+                      if (fileInputRef.current) fileInputRef.current.value = '';
+                      setOpen(false);
+                    } catch (err) {
+                      alert('Failed to create team');
+                    }
                   }}
                 >
                   Create Team


### PR DESCRIPTION
## Summary
- validate at least 1 and no more than 5 speakers before creating a team
- clear file inputs and dialog state after success
- alert if mutation fails
- fix Jest config syntax and polyfill order so tests run

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_684584b887408333b51764a60d5d27ea