### PR TITLE
Extend CSV utilities to handle up to five speakers

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,5 @@
 // jest.config.js
-export default {
+module.exports = {
   preset: 'ts-jest/presets/default-esm',
   // Most tests (components) run in a jsdom environment; server tests can override as needed
   testEnvironment: 'jsdom',

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,8 +1,7 @@
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
-import { JSDOM } from 'jsdom';
 
-// Polyfill TextEncoder/TextDecoder for the test environment
+// Polyfill TextEncoder/TextDecoder before importing jsdom
 if (typeof global.TextEncoder === 'undefined') {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (global as any).TextEncoder = TextEncoder;
@@ -11,6 +10,8 @@ if (typeof global.TextDecoder === 'undefined') {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (global as any).TextDecoder = TextDecoder;
 }
+
+import { JSDOM } from 'jsdom';
 
 // Basic DOM polyfill for the test runner
 if (typeof document === 'undefined') {

--- a/src/lib/__tests__/csv.test.ts
+++ b/src/lib/__tests__/csv.test.ts
@@ -3,7 +3,13 @@ import { parseTeamsCsv, teamsToCsv, TeamCsv } from '../csv';
 describe('CSV utils', () => {
   const teams: TeamCsv[] = [
     { name: 'Alpha', organization: 'Org A', speakers: ['A1', 'A2'] },
-    { name: 'Beta', organization: 'Org B', speakers: ['B1', 'B2', 'B3'] }
+    { name: 'Beta', organization: 'Org B', speakers: ['B1', 'B2', 'B3'] },
+    { name: 'Gamma', organization: 'Org C', speakers: ['C1', 'C2', 'C3', 'C4'] },
+    {
+      name: 'Delta',
+      organization: 'Org D',
+      speakers: ['D1', 'D2', 'D3', 'D4', 'D5'],
+    },
   ];
 
   it('converts teams to CSV and back', () => {
@@ -12,11 +18,22 @@ describe('CSV utils', () => {
     expect(parsed).toEqual(teams);
   });
 
-  it('parses CSV string', () => {
-    const csv = 'Team Name,Organization,Speaker 1,Speaker 2,Speaker 3\n' +
-      'Gamma,Org C,C1,C2,';
+  it('parses CSV string with varying speaker counts', () => {
+    const csv =
+      'Team Name,Organization,Speaker 1,Speaker 2,Speaker 3,Speaker 4,Speaker 5\n' +
+      'Omega,Org X,X1,X2,X3,X4,X5\n' +
+      'Sigma,Org Y,Y1,Y2,Y3,Y4,';
     expect(parseTeamsCsv(csv)).toEqual([
-      { name: 'Gamma', organization: 'Org C', speakers: ['C1', 'C2'] }
+      {
+        name: 'Omega',
+        organization: 'Org X',
+        speakers: ['X1', 'X2', 'X3', 'X4', 'X5'],
+      },
+      {
+        name: 'Sigma',
+        organization: 'Org Y',
+        speakers: ['Y1', 'Y2', 'Y3', 'Y4'],
+      },
     ]);
   });
 });

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -5,10 +5,11 @@ export type TeamCsv = {
 };
 
 export function teamsToCsv(teams: TeamCsv[]): string {
-  const header = 'Team Name,Organization,Speaker 1,Speaker 2,Speaker 3';
+  const header =
+    'Team Name,Organization,Speaker 1,Speaker 2,Speaker 3,Speaker 4,Speaker 5';
   const rows = teams.map(team => {
-    const [s1 = '', s2 = '', s3 = ''] = team.speakers;
-    const values = [team.name, team.organization, s1, s2, s3];
+    const [s1 = '', s2 = '', s3 = '', s4 = '', s5 = ''] = team.speakers;
+    const values = [team.name, team.organization, s1, s2, s3, s4, s5];
     return values.map(v => `"${(v ?? '').replace(/"/g, '""')}"`).join(',');
   });
   return [header, ...rows].join('\n');
@@ -19,9 +20,17 @@ export function parseTeamsCsv(csv: string): TeamCsv[] {
   if (!lines.length) return [];
   lines.shift();
   return lines.map(line => {
-    const [name = '', organization = '', sp1 = '', sp2 = '', sp3 = ''] = line.split(',');
+    const [
+      name = '',
+      organization = '',
+      sp1 = '',
+      sp2 = '',
+      sp3 = '',
+      sp4 = '',
+      sp5 = '',
+    ] = line.split(',');
     const clean = (v: string) => v.trim().replace(/^"|"$/g, '');
-    const speakers = [sp1, sp2, sp3].map(clean).filter(Boolean);
+    const speakers = [sp1, sp2, sp3, sp4, sp5].map(clean).filter(Boolean);
     return { name: clean(name), organization: clean(organization), speakers };
   });
 }


### PR DESCRIPTION
## Summary
- support Speaker 4 and Speaker 5 when exporting and parsing team CSVs
- test csv helpers with teams containing four and five speakers
- fix Jest configuration and setup so tests run

## Testing
- `bun install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684585c79be08333bcda49afdf0828b3