### PR TITLE
Refine Vite env handling

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,27 +7,9 @@ import { componentTagger } from "lovable-tagger";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "VITE_");
   return {
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  define: {
-    'process.env': {
-      VITE_API_BASE_URL: process.env.VITE_API_BASE_URL
-    }
-  },
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-    },
-  },
-    define: {
-      "process.env": env,
-    },
+    server: { host: "::", port: 8080 },
+    plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
+    define: { "process.env": env },
+    resolve: { alias: { "@": path.resolve(__dirname, "./src") } },
   };
 });


### PR DESCRIPTION
## Summary
- simplify env handling in `vite.config.ts` and keep a single `define` block

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test -- -w 1` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458bd7234c83338020f5bfe5ac9e6d