### PR TITLE
Use React act wrapper for async tests

### DIFF
--- a/src/components/__tests__/PairingEngine.test.tsx
+++ b/src/components/__tests__/PairingEngine.test.tsx
@@ -1,5 +1,6 @@
 /// <reference types="@testing-library/jest-dom" />
 import { render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import PairingEngine from '../PairingEngine';
 
@@ -34,7 +35,9 @@ const renderComponent = () =>
 
 describe('PairingEngine', () => {
   it('renders pairings from API', async () => {
-    renderComponent();
+    await act(async () => {
+      renderComponent();
+    });
     await waitFor(() => {
       expect(screen.getByText('Team A', { exact: false })).toBeInTheDocument();
       expect(screen.getByText('Team B', { exact: false })).toBeInTheDocument();

--- a/src/components/__tests__/TeamRoster.test.tsx
+++ b/src/components/__tests__/TeamRoster.test.tsx
@@ -1,5 +1,6 @@
 /// <reference types="@testing-library/jest-dom" />
 import { render, screen, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import TeamRoster from '../TeamRoster';
 
@@ -25,7 +26,9 @@ const renderComponent = () => {
 
 describe('TeamRoster', () => {
   it('displays teams from API', async () => {
-    renderComponent();
+    await act(async () => {
+      renderComponent();
+    });
     await waitFor(() => {
       expect(screen.getByText('Alpha')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
- ensure test utils use `act` from `react`
- wrap async interactions in `await act(async () => {...})`

## Testing
- `bun x jest --config jest.config.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68458bd7caec83339255c9565813821e