### PR TITLE
Remove duplicate define in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,11 +16,6 @@ export default defineConfig(({ mode }) => {
     mode === 'development' &&
     componentTagger(),
   ].filter(Boolean),
-  define: {
-    'process.env': {
-      VITE_API_BASE_URL: process.env.VITE_API_BASE_URL
-    }
-  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary
- drop the extra `define` block from `vite.config.ts`

## Testing
- `bun x jest --config jest.config.cjs` *(fails: Preset ts-jest/presets/default-esm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458f642fcc833386871849a6d2ab48