### PR TITLE
Wrap render in act for tests

### DIFF
--- a/src/components/__tests__/PairingEngine.test.tsx
+++ b/src/components/__tests__/PairingEngine.test.tsx
@@ -26,18 +26,18 @@ globalThis.fetch = jest.fn(() =>
   })
 ) as jest.Mock;
 
-const renderComponent = () =>
-  render(
-    <QueryClientProvider client={new QueryClient()}>
-      <PairingEngine />
-    </QueryClientProvider>
-  );
+const renderComponent = async () =>
+  await act(async () => {
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <PairingEngine />
+      </QueryClientProvider>
+    );
+  });
 
 describe('PairingEngine', () => {
   it('renders pairings from API', async () => {
-    await act(async () => {
-      renderComponent();
-    });
+    await renderComponent();
     await waitFor(() => {
       expect(screen.getByText('Team A', { exact: false })).toBeInTheDocument();
       expect(screen.getByText('Team B', { exact: false })).toBeInTheDocument();

--- a/src/components/__tests__/TeamRoster.test.tsx
+++ b/src/components/__tests__/TeamRoster.test.tsx
@@ -15,20 +15,20 @@ globalThis.fetch = jest.fn(() =>
   })
 ) as jest.Mock;
 
-const renderComponent = () => {
+const renderComponent = async () => {
   const client = new QueryClient();
-  return render(
-    <QueryClientProvider client={client}>
-      <TeamRoster />
-    </QueryClientProvider>
-  );
+  await act(async () => {
+    render(
+      <QueryClientProvider client={client}>
+        <TeamRoster />
+      </QueryClientProvider>
+    );
+  });
 };
 
 describe('TeamRoster', () => {
   it('displays teams from API', async () => {
-    await act(async () => {
-      renderComponent();
-    });
+    await renderComponent();
     await waitFor(() => {
       expect(screen.getByText('Alpha')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
- ensure test render helpers use `act`

## Testing
- `bun test` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68458f6271f8833389d722ee9573ba93