### PR TITLE
Improve frontend JSON parsing

### DIFF
--- a/src/components/LiveAnalytics.tsx
+++ b/src/components/LiveAnalytics.tsx
@@ -5,31 +5,31 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line, PieChart, Pie, Cell } from 'recharts';
 import { Trophy, TrendingUp, Users, Target } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
-import { apiFetch } from '@/lib/api';
+import { apiFetch, expectJson } from '@/lib/api';
 
 const LiveAnalytics = () => {
   const fetchStandings = async () => {
     const res = await apiFetch('/api/analytics/standings');
     if (!res.ok) throw new Error('Failed fetching standings');
-    return res.json();
+    return expectJson(res);
   };
 
   const fetchSpeakers = async () => {
     const res = await apiFetch('/api/analytics/speakers');
     if (!res.ok) throw new Error('Failed fetching speakers');
-    return res.json();
+    return expectJson(res);
   };
 
   const fetchPerformance = async () => {
     const res = await apiFetch('/api/analytics/performance');
     if (!res.ok) throw new Error('Failed fetching performance');
-    return res.json();
+    return expectJson(res);
   };
 
   const fetchResults = async () => {
     const res = await apiFetch('/api/analytics/results');
     if (!res.ok) throw new Error('Failed fetching results');
-    return res.json();
+    return expectJson(res);
   };
 
   const { data: teamStandings = [] } = useQuery({

--- a/src/components/PairingEngine.tsx
+++ b/src/components/PairingEngine.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiFetch } from '@/lib/api';
+import { apiFetch, expectJson } from '@/lib/api';
 
 type Pairing = {
   id: number;
@@ -28,7 +28,7 @@ const PairingEngine: React.FC = () => {
     if (!res.ok) {
       throw new Error('Failed fetching pairings');
     }
-    return res.json();
+    return expectJson(res);
   };
 
   const { data } = useQuery<PairingsResponse>({

--- a/src/components/ScoringInterface.tsx
+++ b/src/components/ScoringInterface.tsx
@@ -9,7 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Target, Trophy, User, Clock } from 'lucide-react';
-import { apiFetch } from "@/lib/api";
+import { apiFetch, expectJson } from "@/lib/api";
 
 type Debate = {
   room: string;
@@ -41,7 +41,7 @@ const ScoringInterface = () => {
   const fetchDebates = async () => {
     const res = await apiFetch('/api/debates');
     if (!res.ok) throw new Error('Failed fetching debates');
-    return res.json();
+    return expectJson(res);
   };
 
   const { data: debates = [] } = useQuery<Debate[]>({
@@ -55,7 +55,7 @@ const ScoringInterface = () => {
     if (!selectedDebate) return [];
     const res = await apiFetch(`/api/scores/${selectedDebate}`);
     if (!res.ok) throw new Error('Failed fetching scores');
-    return res.json();
+    return expectJson(res);
   };
 
   const { data: speakerScores = [] } = useQuery<SpeakerScore[]>({
@@ -78,7 +78,7 @@ const ScoringInterface = () => {
         body: JSON.stringify({ room: selectedDebate, scores })
       });
       if (!res.ok) throw new Error('Failed submitting scores');
-      return res.json();
+      return expectJson(res);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['scores', selectedDebate] });
@@ -100,7 +100,7 @@ const ScoringInterface = () => {
         }),
       });
       if (!res.ok) throw new Error('Failed submitting team scores');
-      return res.json();
+      return expectJson(res);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['scores', selectedDebate] });

--- a/src/components/TeamRoster.tsx
+++ b/src/components/TeamRoster.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Plus, Upload, Download, Search, Edit, Trash2 } from 'lucide-react';
-import { apiFetch } from "@/lib/api";
+import { apiFetch, expectJson } from "@/lib/api";
 import { parseTeamsCsv, teamsToCsv, type TeamCsv } from "@/lib/csv";
 
 type Team = {
@@ -49,7 +49,7 @@ const TeamRoster = () => {
   const fetchTeams = async () => {
     const res = await apiFetch('/api/teams');
     if (!res.ok) throw new Error('Failed fetching teams');
-    return res.json();
+    return expectJson(res);
   };
 
   const { data: teams = [] } = useQuery<Team[]>({ queryKey: ['teams'], queryFn: fetchTeams });
@@ -69,7 +69,7 @@ const TeamRoster = () => {
       })
     });
     if (!res.ok) throw new Error('Failed to add team');
-    return res.json();
+    return expectJson(res);
   };
 
   const { mutateAsync: createTeam } = useMutation({
@@ -86,7 +86,7 @@ const TeamRoster = () => {
       body: JSON.stringify(payload.updates)
     });
     if (!res.ok) throw new Error('Failed to update team');
-    return res.json();
+    return expectJson(res);
   };
 
   const deleteTeam = async (id: number) => {
@@ -94,7 +94,7 @@ const TeamRoster = () => {
       method: 'DELETE'
     });
     if (!res.ok) throw new Error('Failed to delete team');
-    return res.json();
+    return expectJson(res);
   };
 
   const { mutateAsync: editTeam } = useMutation({

--- a/src/components/TournamentManagement.tsx
+++ b/src/components/TournamentManagement.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Users, Trophy, Play, Pause, TrendingUp, Target } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
-import { apiFetch } from '@/lib/api';
+import { apiFetch, expectJson } from '@/lib/api';
 
 interface TournamentManagementProps {
   activeTournament: {
@@ -21,7 +21,7 @@ const TournamentManagement = ({ activeTournament }: TournamentManagementProps) =
   const fetchStats = async () => {
     const res = await apiFetch('/api/tournament/stats');
     if (!res.ok) throw new Error('Failed fetching stats');
-    return res.json();
+    return expectJson(res);
   };
 
   const { data: stats } = useQuery({

--- a/src/components/UserRoleManager.tsx
+++ b/src/components/UserRoleManager.tsx
@@ -10,7 +10,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Plus, Edit, Trash2, Shield, Users, Eye } from 'lucide-react';
-import { apiFetch } from '@/lib/api';
+import { apiFetch, expectJson } from '@/lib/api';
 
 type User = {
   id: number;
@@ -41,7 +41,7 @@ const UserRoleManager = ({ currentUser }: UserRoleManagerProps) => {
   const fetchUsers = async () => {
     const res = await apiFetch('/api/users');
     if (!res.ok) throw new Error('Failed fetching users');
-    return res.json();
+    return expectJson(res);
   };
 
   const { data: users = [] } = useQuery<User[]>({
@@ -57,7 +57,7 @@ const UserRoleManager = ({ currentUser }: UserRoleManagerProps) => {
       body: JSON.stringify({ name, email, role, lastActive: 'just now', status: 'active', permissions: [] })
     });
     if (!res.ok) throw new Error('Failed to add user');
-    return res.json();
+    return expectJson(res);
   };
 
   const updateUser = async (user: User) => {
@@ -67,13 +67,13 @@ const UserRoleManager = ({ currentUser }: UserRoleManagerProps) => {
       body: JSON.stringify(user)
     });
     if (!res.ok) throw new Error('Failed to update user');
-    return res.json();
+    return expectJson(res);
   };
 
   const deleteUser = async (id: number) => {
     const res = await apiFetch(`/api/users/${id}`, { method: 'DELETE' });
     if (!res.ok) throw new Error('Failed to delete user');
-    return res.json();
+    return expectJson(res);
   };
 
   const { mutateAsync: createUser } = useMutation({

--- a/src/components/__tests__/PairingEngine.test.tsx
+++ b/src/components/__tests__/PairingEngine.test.tsx
@@ -22,6 +22,7 @@ const mockResponse = {
 globalThis.fetch = jest.fn(() =>
   Promise.resolve({
     ok: true,
+    headers: { get: () => 'application/json' },
     json: () => Promise.resolve(mockResponse),
   })
 ) as jest.Mock;

--- a/src/components/__tests__/TeamRoster.test.tsx
+++ b/src/components/__tests__/TeamRoster.test.tsx
@@ -11,6 +11,7 @@ const mockTeams = [
 globalThis.fetch = jest.fn(() =>
   Promise.resolve({
     ok: true,
+    headers: { get: () => 'application/json' },
     json: () => Promise.resolve(mockTeams)
   })
 ) as jest.Mock;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,3 +9,19 @@ export function apiFetch(input: string, init?: RequestInit) {
   const url = input.startsWith('http') ? input : `${apiBaseUrl}${input}`;
   return fetch(url, init);
 }
+
+// Helper to parse JSON responses with a clear error when the body isn't JSON
+export async function expectJson(res: Response) {
+  const contentType = res.headers.get('content-type') ?? '';
+  if (!contentType.includes('application/json')) {
+    const snippet = (await res.text()).slice(0, 100);
+    throw new Error(`Expected JSON response but got '${contentType}': ${snippet}`);
+  }
+  try {
+    return await res.json();
+  } catch (err) {
+    const text = await res.text();
+    const snippet = text.slice(0, 100);
+    throw new Error(`Failed to parse JSON response: ${snippet}`);
+  }
+}


### PR DESCRIPTION
## Summary
- guard against HTML responses by adding `expectJson` helper
- use new JSON validator across components
- update tests for new fetch mocks

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684596873c48833397acfaa312a805c5