### PR TITLE
Refactor analytics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ npm run server
 
 By default it listens on `http://localhost:3001` unless the `PORT` environment variable is set. The frontend expects the server URL to match `VITE_API_BASE_URL`.
 
-When `SUPABASE_URL` and `SUPABASE_ANON_KEY` are provided the server connects to your Supabase project. If those variables are missing it falls back to the local JSON file located at `server/db.json`.
+When `SUPABASE_URL` and `SUPABASE_ANON_KEY` are provided the server connects to your Supabase project.
 
 ### Running Tests
 

--- a/server/analytics.ts
+++ b/server/analytics.ts
@@ -1,86 +1,75 @@
+import type { Express } from 'express';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export function registerAnalyticsRoutes(app: Express, supabase: SupabaseClient) {
+
 // ─── Analytics Endpoints ───────────────────────────────────────────────────
 
-// GET /api/analytics/standings
-app.get('/api/analytics/standings', async (req, res) => {
-  await db.read();
-  const { teams, pairings, scores } = db.data;
+app.get('/api/analytics/standings', async (_req, res) => {
+  const { data: teams, error: tErr } = await supabase.from('teams').select('*');
+  const { data: pairings, error: pErr } = await supabase.from('pairings').select('*');
+  const { data: scores, error: sErr } = await supabase.from('scores').select('*');
+  if (tErr || pErr || sErr) {
+    const msg = tErr?.message || pErr?.message || sErr?.message;
+    return res.status(500).json({ error: msg });
+  }
 
-  // build team stats map
   const map = new Map<string, { team: string; wins: number; losses: number; speakerPoints: number }>();
-  teams.forEach(t => {
-    map.set(t.name, { team: t.name, wins: 0, losses: 0, speakerPoints: 0 });
-  });
-
-  // tally wins / losses
+  teams.forEach(t => map.set(t.name, { team: t.name, wins: 0, losses: 0, speakerPoints: 0 }));
   pairings.forEach(p => {
     if (p.status === 'completed') {
       const prop = map.get(p.proposition)!;
-      const opp  = map.get(p.opposition)!;
-      if (p.propWins) {
-        prop.wins += 1;
-        opp.losses += 1;
-      } else {
-        prop.losses += 1;
-        opp.wins += 1;
-      }
+      const opp = map.get(p.opposition)!;
+      if (p.propWins) { prop.wins++; opp.losses++; }
+      else             { prop.losses++; opp.wins++; }
     }
   });
-
-  // add speaker points
   scores.forEach(s => {
-    const entry = map.get(s.team);
-    if (entry) entry.speakerPoints += s.total ?? 0;
+    const e = map.get(s.team);
+    if (e) e.speakerPoints += s.total || 0;
   });
 
-  // convert to array, compute ranking points and sort
-  const standings = Array.from(map.values()).map(t => ({
-    ...t,
-    points: t.wins * 3
-  })).sort((a, b) => {
-    if (b.points !== a.points) return b.points - a.points;
-    return b.speakerPoints - a.speakerPoints;
-  });
+  const standings = Array.from(map.values())
+    .map(t => ({ ...t, points: t.wins * 3 }))
+    .sort((a, b) => b.points - a.points || b.speakerPoints - a.speakerPoints)
+    .map((t, i) => ({ ...t, rank: i + 1 }));
 
-  standings.forEach((s, i) => s['rank'] = i + 1);
   res.json(standings);
 });
 
-// GET /api/analytics/speakers
-app.get('/api/analytics/speakers', async (req, res) => {
-  await db.read();
-  const { scores } = db.data;
+app.get('/api/analytics/speakers', async (_req, res) => {
+  const { data: scores, error } = await supabase.from('scores').select('*');
+  if (error) return res.status(500).json({ error: error.message });
 
   const map = new Map<string, { name: string; team: string; total: number; count: number }>();
   scores.forEach(s => {
-    if (!map.has(s.speaker)) {
-      map.set(s.speaker, { name: s.speaker, team: s.team, total: 0, count: 0 });
-    }
+    if (!map.has(s.speaker)) map.set(s.speaker, { name: s.speaker, team: s.team, total: 0, count: 0 });
     const e = map.get(s.speaker)!;
-    e.total += s.total ?? 0;
-    e.count += 1;
+    e.total += s.total || 0;
+    e.count++;
   });
 
   const speakers = Array.from(map.values())
     .map(s => ({ ...s, average: s.count ? s.total / s.count : 0 }))
-    .sort((a, b) => b.average - a.average);
+    .sort((a, b) => b.average - a.average)
+    .map((s, i) => ({ ...s, rank: i + 1 }));
 
-  speakers.forEach((s, i) => s['rank'] = i + 1);
   res.json(speakers);
 });
 
-// GET /api/analytics/performance
-app.get('/api/analytics/performance', async (req, res) => {
-  await db.read();
-  const { pairings, scores } = db.data;
+app.get('/api/analytics/performance', async (_req, res) => {
+  const { data: pairings, error: pErr } = await supabase.from('pairings').select('*');
+  const { data: scores, error: sErr } = await supabase.from('scores').select('*');
+  if (pErr || sErr) { return res.status(500).json({ error: (pErr || sErr)!.message }); }
 
   const rounds = new Map<number, { round: number; total: number; debates: number }>();
   scores.forEach(s => {
     const p = pairings.find(p => p.room === s.room);
-    const rnd = p ? p.round : 1;
-    if (!rounds.has(rnd)) rounds.set(rnd, { round: rnd, total: 0, debates: 0 });
-    const e = rounds.get(rnd)!;
-    e.total += s.total ?? 0;
-    e.debates += 1;
+    const r = p ? p.round : 1;
+    if (!rounds.has(r)) rounds.set(r, { round: r, total: 0, debates: 0 });
+    const e = rounds.get(r)!;
+    e.total += s.total || 0;
+    e.debates++;
   });
 
   const performance = Array.from(rounds.values())
@@ -90,29 +79,22 @@ app.get('/api/analytics/performance', async (req, res) => {
   res.json(performance);
 });
 
-// GET /api/analytics/results
-app.get('/api/analytics/results', async (req, res) => {
-  await db.read();
-  const { pairings } = db.data;
+app.get('/api/analytics/results', async (_req, res) => {
+  const { data: pairings, error } = await supabase.from('pairings').select('*');
+  if (error) return res.status(500).json({ error: error.message });
 
   let propWins = 0, oppWins = 0, ties = 0;
   pairings.forEach(p => {
     if (p.status === 'completed') {
-      if (p.propWins === true)      propWins++;
+      if (p.propWins === true) propWins++;
       else if (p.propWins === false) oppWins++;
-      else                           ties++;
+      else                        ties++;
     }
   });
 
   res.json({ propWins, oppWins, ties });
 });
 
-// ─── Start Server ──────────────────────────────────────────────────────────
-const PORT = process.env.PORT || 3001;
-if (process.env.NODE_ENV !== 'test') {
-  app.listen(PORT, () => {
-    console.log(`Server listening on ${PORT}`);
-  });
 }
 
-export default app;
+export default registerAnalyticsRoutes;

--- a/server/server.ts
+++ b/server/server.ts
@@ -2,6 +2,7 @@
 import express from 'express';
 import cors from 'cors';
 import { createClient } from '@supabase/supabase-js';
+import { registerAnalyticsRoutes } from './analytics';
 
 const app = express();
 app.use(cors());
@@ -255,101 +256,9 @@ app.delete('/api/users/:id', async (req, res) => {
   res.json(data);
 });
 
-// ─── Analytics Endpoints ───────────────────────────────────────────────────
+// Register analytics routes after CRUD endpoints
+registerAnalyticsRoutes(app, supabase);
 
-// 1) Standings
-app.get('/api/analytics/standings', async (_req, res) => {
-  const { data: teams, error: tErr } = await supabase.from('teams').select('*');
-  const { data: pairings, error: pErr } = await supabase.from('pairings').select('*');
-  const { data: scores, error: sErr } = await supabase.from('scores').select('*');
-  if (tErr || pErr || sErr) {
-    const msg = tErr?.message || pErr?.message || sErr?.message;
-    return res.status(500).json({ error: msg });
-  }
-
-  const map = new Map<string, { team: string; wins: number; losses: number; speakerPoints: number }>();
-  teams.forEach(t => map.set(t.name, { team: t.name, wins: 0, losses: 0, speakerPoints: 0 }));
-  pairings.forEach(p => {
-    if (p.status === 'completed') {
-      const prop = map.get(p.proposition)!;
-      const opp = map.get(p.opposition)!;
-      if (p.propWins) { prop.wins++; opp.losses++; }
-      else             { prop.losses++; opp.wins++; }
-    }
-  });
-  scores.forEach(s => {
-    const e = map.get(s.team);
-    if (e) e.speakerPoints += s.total || 0;
-  });
-
-  const standings = Array.from(map.values())
-    .map(t => ({ ...t, points: t.wins * 3 }))
-    .sort((a, b) => b.points - a.points || b.speakerPoints - a.speakerPoints)
-    .map((t, i) => ({ ...t, rank: i + 1 }));
-
-  res.json(standings);
-});
-
-// 2) Speakers
-app.get('/api/analytics/speakers', async (_req, res) => {
-  const { data: scores, error } = await supabase.from('scores').select('*');
-  if (error) return res.status(500).json({ error: error.message });
-
-  const map = new Map<string, { name: string; team: string; total: number; count: number }>();
-  scores.forEach(s => {
-    if (!map.has(s.speaker)) map.set(s.speaker, { name: s.speaker, team: s.team, total: 0, count: 0 });
-    const e = map.get(s.speaker)!;
-    e.total += s.total || 0;
-    e.count++;
-  });
-
-  const speakers = Array.from(map.values())
-    .map(s => ({ ...s, average: s.count ? s.total / s.count : 0 }))
-    .sort((a, b) => b.average - a.average)
-    .map((s, i) => ({ ...s, rank: i + 1 }));
-
-  res.json(speakers);
-});
-
-// 3) Performance
-app.get('/api/analytics/performance', async (_req, res) => {
-  const { data: pairings, error: pErr } = await supabase.from('pairings').select('*');
-  const { data: scores, error: sErr } = await supabase.from('scores').select('*');
-  if (pErr || sErr) { return res.status(500).json({ error: (pErr || sErr)!.message }); }
-
-  const rounds = new Map<number, { round: number; total: number; debates: number }>();
-  scores.forEach(s => {
-    const p = pairings.find(p => p.room === s.room);
-    const r = p ? p.round : 1;
-    if (!rounds.has(r)) rounds.set(r, { round: r, total: 0, debates: 0 });
-    const e = rounds.get(r)!;
-    e.total += s.total || 0;
-    e.debates++;
-  });
-
-  const performance = Array.from(rounds.values())
-    .map(r => ({ round: `R${r.round}`, avgScore: r.debates ? r.total / r.debates : 0, debates: r.debates }))
-    .sort((a, b) => parseInt(a.round.slice(1)) - parseInt(b.round.slice(1)));
-
-  res.json(performance);
-});
-
-// 4) Results summary
-app.get('/api/analytics/results', async (_req, res) => {
-  const { data: pairings, error } = await supabase.from('pairings').select('*');
-  if (error) return res.status(500).json({ error: error.message });
-
-  let propWins = 0, oppWins = 0, ties = 0;
-  pairings.forEach(p => {
-    if (p.status === 'completed') {
-      if (p.propWins === true) propWins++;
-      else if (p.propWins === false) oppWins++;
-      else                        ties++;
-    }
-  });
-
-  res.json({ propWins, oppWins, ties });
-});
 
 // ─── Start server ─────────────────────────────────────────────────────────
 
@@ -358,4 +267,5 @@ if (process.env.NODE_ENV !== 'test') {
   app.listen(PORT, () => console.log(`Server listening on ${PORT}`));
 }
 
+export { app, supabase };
 export default app;


### PR DESCRIPTION
## Summary
- register analytics routes through a helper and call from `server.ts`
- remove old lowdb usage and reference to db.json
- simplify server tests with inline seed data and env vars

## Testing
- `npm test --silent` *(fails: import.meta not allowed, supabase mocks)*

------
https://chatgpt.com/codex/tasks/task_e_6845ab224bbc83338ae1c942a5c5ea03