### PR TITLE
Add JSON seed data and configure tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "server": "node --loader ts-node/esm server/server.ts",
-    "test": "bun x jest --config jest.config.cjs"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.cjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/server/db.json
+++ b/server/db.json
@@ -1,0 +1,17 @@
+{
+  "teams": [
+    { "id": 1, "name": "Alpha", "organization": "Org", "speakers": ["A", "B"] }
+  ],
+  "pairings": [
+    { "id": 1, "round": 1, "room": "A1", "proposition": "Alpha", "opposition": "Beta", "status": "pending", "propWins": null }
+  ],
+  "scores": [
+    { "id": 1, "room": "A1", "team": "Alpha", "speaker": "A", "total": 75 }
+  ],
+  "settings": [
+    { "id": 1, "currentRound": 1 }
+  ],
+  "users": [
+    { "id": 1, "name": "Admin", "email": "admin@example.com", "role": "Judge" }
+  ]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "module": "NodeNext",
     "target": "ES2022",
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
## Summary
- add example `server/db.json` seed
- tweak Jest tsconfig for NodeNext module resolution
- run Jest via `node --experimental-vm-modules`

## Testing
- `npm test --silent` *(fails: ReferenceError and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_6845ab21bab083339fc60416e1bfe9a3