### PR TITLE
Fix default generic type for expectJson

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,7 +15,7 @@ export function apiFetch(input: string, init?: RequestInit) {
 }
 
 // Helper to parse JSON responses with a clear error when the body isn't JSON
-export async function expectJson<T = any>(res: Response): Promise<T> {
+export async function expectJson<T = unknown>(res: Response): Promise<T> {
   const contentType = res.headers.get('content-type') ?? '';
   const text = await res.text();
 


### PR DESCRIPTION
## Summary
- set `expectJson` default generic to `unknown`
- confirm lint no longer reports `any` usage in `src/lib/api.ts`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845b50a568c83339a5b1a897ee71758