### PR TITLE
Add pairings and settings tables

### DIFF
--- a/supabase/migrations/0001_create_schema.sql
+++ b/supabase/migrations/0001_create_schema.sql
@@ -62,6 +62,20 @@ CREATE TABLE IF NOT EXISTS public.rounds (
     updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- Pairings
+CREATE TABLE IF NOT EXISTS public.pairings (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    round integer NOT NULL,
+    room text NOT NULL,
+    proposition text NOT NULL,
+    opposition text NOT NULL,
+    judge text,
+    status text DEFAULT 'scheduled',
+    "propWins" boolean,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
 -- Debates
 CREATE TABLE IF NOT EXISTS public.debates (
     id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -91,15 +105,25 @@ CREATE TABLE IF NOT EXISTS public.scores (
     updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- Settings
+CREATE TABLE IF NOT EXISTS public.settings (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    "currentRound" integer NOT NULL DEFAULT 1,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now()
+);
+
 -- Enable RLS and create policies
 ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.tournaments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.teams ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.speakers ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.rounds ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.pairings ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.debates ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.debate_teams ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.scores ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.settings ENABLE ROW LEVEL SECURITY;
 
 -- Common policy helpers
 CREATE POLICY "All select" ON public.users FOR SELECT USING (auth.uid() = id OR current_user_role() = 'admin');
@@ -118,6 +142,9 @@ CREATE POLICY "Manage speakers" ON public.speakers FOR ALL USING (current_user_r
 CREATE POLICY "Read rounds" ON public.rounds FOR SELECT USING (true);
 CREATE POLICY "Manage rounds" ON public.rounds FOR ALL USING (current_user_role() IN ('admin','organizer'));
 
+CREATE POLICY "Read pairings" ON public.pairings FOR SELECT USING (true);
+CREATE POLICY "Manage pairings" ON public.pairings FOR ALL USING (current_user_role() IN ('admin','organizer'));
+
 CREATE POLICY "Read debates" ON public.debates FOR SELECT USING (true);
 CREATE POLICY "Manage debates" ON public.debates FOR ALL USING (current_user_role() IN ('admin','organizer'));
 
@@ -126,4 +153,7 @@ CREATE POLICY "Manage debate teams" ON public.debate_teams FOR ALL USING (curren
 
 CREATE POLICY "Read scores" ON public.scores FOR SELECT USING (true);
 CREATE POLICY "Manage scores" ON public.scores FOR ALL USING (current_user_role() IN ('admin','organizer'));
+
+CREATE POLICY "Read settings" ON public.settings FOR SELECT USING (true);
+CREATE POLICY "Manage settings" ON public.settings FOR ALL USING (current_user_role() IN ('admin','organizer'));
 

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -4,3 +4,8 @@
 INSERT INTO public.users (id, email, role, name)
 VALUES ('00000000-0000-0000-0000-000000000001', 'admin@example.com', 'admin', 'Admin User')
 ON CONFLICT DO NOTHING;
+
+-- Initialize settings with round 1
+INSERT INTO public.settings (id, "currentRound")
+VALUES ('11111111-1111-1111-1111-111111111111', 1)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary
- expand initial Supabase schema to include `pairings` and `settings`
- add corresponding RLS policies
- seed a default settings row

## Testing
- `npm install`
- `npm test` *(fails: ReferenceError: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6845b50a10448333a8788bb9236f8a32