### PR TITLE
Add backend pairing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ Then execute all unit tests:
 npm test --silent
 ```
 
+This command runs both frontend and backend tests, including the Swiss pairing
+and bracket generation checks located under `server/__tests__`.
+
 ## 🎯 Success Criteria
 
 The platform aims to enable tournament administrators to:

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -11,7 +11,7 @@ module.exports = {
   setupFiles: ['<rootDir>/jest.polyfill.ts'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 
-  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/server/__tests__/', '/src/components/__tests__/'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/', '/src/components/__tests__/'],
 
   transformIgnorePatterns: [
     '/node_modules/(?!(?:@supabase)/)'

--- a/server/__tests__/pairingUtils.test.ts
+++ b/server/__tests__/pairingUtils.test.ts
@@ -1,0 +1,47 @@
+/** @jest-environment node */
+import { swissPairings, generateBracket, Pairing, Team } from '../pairingUtils';
+
+describe('Swiss pairing algorithm', () => {
+  it('generates pairings and assigns BYE with odd number of teams', () => {
+    const teams: Team[] = [
+      { name: 'A', wins: 2, speakerPoints: 75 },
+      { name: 'B', wins: 2, speakerPoints: 70 },
+      { name: 'C', wins: 1, speakerPoints: 60 },
+      { name: 'D', wins: 1, speakerPoints: 50 },
+      { name: 'E', wins: 0, speakerPoints: 40 },
+    ];
+    const history: Pairing[] = [{ proposition: 'A', opposition: 'B' }];
+    const result = swissPairings(teams, history);
+    expect(result.bye).toBe('E');
+    // ensure no rematch of A vs B
+    const match = result.pairings.some(
+      p =>
+        [p.proposition, p.opposition].sort().join('-') ===
+        ['A', 'B'].sort().join('-')
+    );
+    expect(match).toBe(false);
+    expect(result.pairings).toHaveLength(2);
+  });
+});
+
+describe('Bracket generation', () => {
+  it('pairs top and bottom seeds correctly', () => {
+    const teams: Team[] = [
+      { name: 'A', wins: 4, speakerPoints: 90 },
+      { name: 'B', wins: 3, speakerPoints: 85 },
+      { name: 'C', wins: 3, speakerPoints: 80 },
+      { name: 'D', wins: 2, speakerPoints: 70 },
+      { name: 'E', wins: 2, speakerPoints: 65 },
+      { name: 'F', wins: 1, speakerPoints: 60 },
+      { name: 'G', wins: 1, speakerPoints: 55 },
+      { name: 'H', wins: 0, speakerPoints: 50 },
+    ];
+    const bracket = generateBracket(teams);
+    expect(bracket).toEqual([
+      { proposition: 'A', opposition: 'H' },
+      { proposition: 'B', opposition: 'G' },
+      { proposition: 'C', opposition: 'F' },
+      { proposition: 'D', opposition: 'E' },
+    ]);
+  });
+});

--- a/server/__tests__/server.test.ts
+++ b/server/__tests__/server.test.ts
@@ -2,6 +2,7 @@
 import request from 'supertest';
 import type { Express } from 'express';
 import { createClient } from '@supabase/supabase-js';
+import { jest } from '@jest/globals';
 
 // Inline seed data used by the mocked Supabase client
 const seed = {

--- a/server/pairingUtils.ts
+++ b/server/pairingUtils.ts
@@ -1,0 +1,62 @@
+export interface Team {
+  name: string;
+  wins: number;
+  speakerPoints: number;
+}
+
+export interface Pairing {
+  proposition: string;
+  opposition: string;
+}
+
+export interface SwissResult {
+  pairings: Pairing[];
+  bye: string | null;
+}
+
+export function swissPairings(
+  teams: Team[],
+  history: Pairing[] = []
+): SwissResult {
+  const sorted = [...teams].sort(
+    (a, b) => b.wins - a.wins || b.speakerPoints - a.speakerPoints
+  );
+
+  let bye: string | null = null;
+  if (sorted.length % 2 === 1) {
+    bye = sorted.pop()!.name;
+  }
+
+  const played = new Set(
+    history.map(h => [h.proposition, h.opposition].sort().join('|'))
+  );
+
+  const pairings: Pairing[] = [];
+  for (let i = 0; i < sorted.length; i += 2) {
+    let a = sorted[i];
+    let b = sorted[i + 1];
+    if (played.has([a.name, b.name].sort().join('|')) && i + 2 < sorted.length) {
+      const c = sorted[i + 2];
+      sorted[i + 1] = c;
+      sorted[i + 2] = b;
+      b = c;
+    }
+    pairings.push({ proposition: a.name, opposition: b.name });
+  }
+
+  return { pairings, bye };
+}
+
+export function generateBracket(teams: Team[]): Pairing[] {
+  const sorted = [...teams].sort(
+    (a, b) => b.wins - a.wins || b.speakerPoints - a.speakerPoints
+  );
+  const pairings: Pairing[] = [];
+  for (let i = 0; i < Math.floor(sorted.length / 2); i++) {
+    pairings.push({
+      proposition: sorted[i].name,
+      opposition: sorted[sorted.length - 1 - i].name,
+    });
+  }
+  return pairings;
+}


### PR DESCRIPTION
## Summary
- add Swiss pairing & bracket utilities
- test backend Swiss pairings with BYEs and bracket generation
- fix server test mocking for ESM
- ensure server tests run by removing ignore pattern
- document running all tests

## Testing
- `bun install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845bc017cd483338ae88e11ded93675