### PR TITLE
Add pairing constraints and solver

### DIFF
--- a/src/lib/pairing/__tests__/applyConstraints.test.ts
+++ b/src/lib/pairing/__tests__/applyConstraints.test.ts
@@ -1,0 +1,15 @@
+import { applyConstraints, NoRepeatMatch, Pairing } from '../constraints';
+
+describe('applyConstraints', () => {
+  it('avoids repeated matchups', () => {
+    const prev: Pairing[] = [
+      { round: 1, room: 'R1', proposition: 'A', opposition: 'B', status: 'done' }
+    ];
+    const current: Pairing[] = [
+      { round: 2, room: 'R1', proposition: 'A', opposition: 'B' },
+      { round: 2, room: 'R2', proposition: 'C', opposition: 'D' }
+    ];
+    const result = applyConstraints(current, [new NoRepeatMatch()], { previousPairings: prev });
+    expect(result[0].opposition).not.toBe('B');
+  });
+});

--- a/src/lib/pairing/bracket.ts
+++ b/src/lib/pairing/bracket.ts
@@ -1,0 +1,26 @@
+import { Pairing, Constraint, applyConstraints, ConstraintContext } from './constraints';
+import { loadConstraintSettings } from './config';
+
+export async function generateBracket(
+  teams: string[],
+  previousPairings: Pairing[],
+  constraints: Constraint[] = [],
+  rooms: string[] = []
+): Promise<Pairing[]> {
+  const settings = await loadConstraintSettings();
+  const active = constraints.filter(c => settings[c.type as keyof typeof settings]);
+
+  const pairings: Pairing[] = [];
+  const n = teams.length;
+  for (let i = 0; i < n / 2; i++) {
+    pairings.push({
+      round: 1,
+      room: rooms[i] || `Room ${i + 1}`,
+      proposition: teams[i],
+      opposition: teams[n - 1 - i],
+      status: 'scheduled',
+    });
+  }
+  const context: ConstraintContext = { previousPairings, roomList: rooms };
+  return applyConstraints(pairings, active, context);
+}

--- a/src/lib/pairing/config.ts
+++ b/src/lib/pairing/config.ts
@@ -1,0 +1,22 @@
+import { supabase } from '../supabase';
+import defaultConfig from './constraints-config.json';
+
+export interface ConstraintSettings {
+  NoRepeatMatch: boolean;
+  JudgeAvailability: boolean;
+  RoomCapacity: boolean;
+}
+
+export async function loadConstraintSettings(): Promise<ConstraintSettings> {
+  try {
+    const { data, error } = await supabase
+      .from('constraint_settings')
+      .select('name, enabled');
+    if (error || !data) throw error;
+    const cfg: any = { ...defaultConfig };
+    for (const row of data) cfg[row.name] = row.enabled;
+    return cfg as ConstraintSettings;
+  } catch {
+    return defaultConfig as ConstraintSettings;
+  }
+}

--- a/src/lib/pairing/constraints-config.json
+++ b/src/lib/pairing/constraints-config.json
@@ -1,0 +1,5 @@
+{
+  "NoRepeatMatch": true,
+  "JudgeAvailability": true,
+  "RoomCapacity": true
+}

--- a/src/lib/pairing/constraints.ts
+++ b/src/lib/pairing/constraints.ts
@@ -1,0 +1,109 @@
+export type Pairing = {
+  round: number;
+  room: string;
+  proposition: string;
+  opposition: string;
+  judge?: string;
+  status?: string;
+  propWins?: boolean | null;
+};
+
+export interface ConstraintContext {
+  previousPairings: Pairing[];
+  roomList?: string[];
+  judgesAvailability?: Record<string, number[]>;
+  roomCapacity?: Record<string, number>;
+}
+
+export interface Constraint {
+  type: string;
+  apply(pairings: Pairing[], context: ConstraintContext): Pairing[];
+}
+
+function canonical(a: string, b: string) {
+  return a < b ? `${a}::${b}` : `${b}::${a}`;
+}
+
+export class NoRepeatMatch implements Constraint {
+  type = 'NoRepeatMatch' as const;
+  apply(pairings: Pairing[], context: ConstraintContext): Pairing[] {
+    const history = new Set(
+      context.previousPairings.map(p => canonical(p.proposition, p.opposition))
+    );
+    const used = new Set<string>();
+    for (let i = 0; i < pairings.length; i++) {
+      const p = pairings[i];
+      let key = canonical(p.proposition, p.opposition);
+      if (history.has(key) || used.has(key)) {
+        for (let j = i + 1; j < pairings.length; j++) {
+          const alt1 = canonical(p.proposition, pairings[j].opposition);
+          const alt2 = canonical(pairings[j].proposition, p.opposition);
+          if (
+            !history.has(alt1) &&
+            !used.has(alt1) &&
+            !history.has(alt2) &&
+            !used.has(alt2)
+          ) {
+            const tmp = pairings[i].opposition;
+            pairings[i].opposition = pairings[j].opposition;
+            pairings[j].opposition = tmp;
+            key = canonical(pairings[i].proposition, pairings[i].opposition);
+            used.add(key);
+            used.add(canonical(pairings[j].proposition, pairings[j].opposition));
+            break;
+          }
+        }
+      } else {
+        used.add(key);
+      }
+    }
+    return pairings;
+  }
+}
+
+export class JudgeAvailability implements Constraint {
+  type = 'JudgeAvailability' as const;
+  constructor(public availability: Record<string, number[]>) {}
+  apply(pairings: Pairing[], _context: ConstraintContext): Pairing[] {
+    for (const p of pairings) {
+      if (
+        p.judge &&
+        this.availability[p.judge] &&
+        !this.availability[p.judge].includes(p.round)
+      ) {
+        // judge unavailable, remove assignment
+        p.judge = undefined;
+      }
+    }
+    return pairings;
+  }
+}
+
+export class RoomCapacity implements Constraint {
+  type = 'RoomCapacity' as const;
+  constructor(public capacity: Record<string, number>, public rooms: string[]) {}
+  apply(pairings: Pairing[], _context: ConstraintContext): Pairing[] {
+    const count: Record<string, number> = {};
+    for (const p of pairings) {
+      const cap = this.capacity[p.room] ?? 1;
+      count[p.room] = (count[p.room] || 0) + 1;
+      if (count[p.room] > cap) {
+        // find free room
+        const target = this.rooms.find(r => (count[r] || 0) < (this.capacity[r] ?? 1));
+        if (target) {
+          p.room = target;
+          count[target] = (count[target] || 0) + 1;
+        }
+      }
+    }
+    return pairings;
+  }
+}
+
+export function applyConstraints(
+  pairings: Pairing[],
+  constraints: Constraint[],
+  context: ConstraintContext
+): Pairing[] {
+  return constraints.reduce((acc, c) => c.apply(acc, context), pairings);
+}

--- a/src/lib/pairing/index.ts
+++ b/src/lib/pairing/index.ts
@@ -1,0 +1,4 @@
+export * from './constraints';
+export * from './config';
+export * from './swiss';
+export * from './bracket';

--- a/src/lib/pairing/swiss.ts
+++ b/src/lib/pairing/swiss.ts
@@ -1,0 +1,27 @@
+import { Pairing, Constraint, applyConstraints, ConstraintContext } from './constraints';
+import { loadConstraintSettings } from './config';
+
+export async function generateSwissPairings(
+  teams: string[],
+  round: number,
+  previousPairings: Pairing[],
+  constraints: Constraint[] = [],
+  rooms: string[] = []
+): Promise<Pairing[]> {
+  const settings = await loadConstraintSettings();
+  const active = constraints.filter(c => settings[c.type as keyof typeof settings]);
+
+  const sorted = [...teams].sort();
+  const pairings: Pairing[] = [];
+  for (let i = 0; i < sorted.length; i += 2) {
+    pairings.push({
+      round,
+      room: rooms[i / 2] || `Room ${i / 2 + 1}`,
+      proposition: sorted[i],
+      opposition: sorted[i + 1],
+      status: 'scheduled',
+    });
+  }
+  const context: ConstraintContext = { previousPairings, roomList: rooms };
+  return applyConstraints(pairings, active, context);
+}


### PR DESCRIPTION
## Summary
- introduce generic constraint utilities and solver
- include Swiss and bracket pair generators that use the solver
- add configurable constraint settings with Supabase fallback
- include test for no-repeat match constraint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845bc02365083338a45928e04755372