### PR TITLE
Fix tsconfig settings and Vite plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "@types/testing-library__jest-dom": "^6.0.0",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.9.0",

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "module": "NodeNext",
+    "module": "ESNext",
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -6,7 +6,7 @@
     "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
+    "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, loadEnv } from 'vite'
-import react from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react-swc'
 import path from 'path'
 import componentTagger from 'vite-plugin-react-component-tagger'
 


### PR DESCRIPTION
## Summary
- switch Vite plugin to `@vitejs/plugin-react-swc`
- set `moduleResolution` for node build
- use `ESNext` module for app build
- drop unused `@types/testing-library__jest-dom`

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*
- `npm run lint` *(fails: Cannot find module 'eslint/use-at-your-own-risk')*

------
https://chatgpt.com/codex/tasks/task_e_6845bcd730a08333bafc113d62c6d890