### PR TITLE
Update roadmap with completed Phase 1 items

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,11 +239,11 @@ The platform aims to enable tournament administrators to:
 - Basic API endpoints
 - Data validation and security
 
-### Phase 2: Pairing Algorithms (Current Priority)
-- Swiss system implementation
-- Elimination bracket generation
-- Constraint satisfaction solver
-- Algorithm testing and validation
+### Phase 2: Core Tournament Management (Weeks 4-6)
+- Tournament creation with format selection
+- Team and speaker management linked to tournaments
+- Round tracking with progression logic
+- Tournament status and settings management
 
 ### Phase 3: Real-time Features
 - WebSocket integration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,6 +18,9 @@
 - User role management interface (UI only)
 - Tournament dashboard layout
 - Basic API endpoints
+- Backend database integration via Supabase
+- Authentication system with role-based access
+- API layer refactoring with real queries
 
 ### 🚧 In Progress
 - Initial tournament management


### PR DESCRIPTION
## Summary
- sync Phase 2 title and bullet points across README and ROADMAP
- move database, auth and API refactor work to the Completed Features list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845c7b537b88333903804c87c2ccdb1