### PR TITLE
Add endpoints for speakers and rounds

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -47,6 +47,18 @@ const teamSchema = z.object({
   speakerPoints: z.number().optional(),
 })
 
+const speakerSchema = z.object({
+  team_id: z.string(),
+  name: z.string(),
+  position: z.number().optional(),
+})
+
+const roundSchema = z.object({
+  tournament_id: z.string(),
+  round_number: z.number(),
+  status: z.string().optional(),
+})
+
 const pairingSchema = z.object({
   round: z.number(),
   room: z.string(),
@@ -157,6 +169,67 @@ app.delete('/api/teams/:id', async (req, res) => {
   const id = Number(req.params.id)
   const { data, error } = await supabase
     .from('teams')
+    .delete()
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) return res.status(404).json({ error: error.message })
+  res.json(data)
+})
+
+// ─── Speakers CRUD ─────────────────────────────────────────────────────────
+
+app.get('/api/speakers', async (_req, res) => {
+  const { data, error } = await supabase.from('speakers').select('*')
+  if (error) return res.status(500).json({ error: error.message })
+  res.json(data)
+})
+
+app.get('/api/speakers/:id', async (req, res) => {
+  const id = req.params.id
+  const { data, error } = await supabase
+    .from('speakers')
+    .select('*')
+    .eq('id', id)
+    .single()
+  if (error) return res.status(404).json({ error: error.message })
+  res.json(data)
+})
+
+app.post('/api/speakers', async (req, res) => {
+  const parsed = speakerSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request body' })
+  }
+  const { data, error } = await supabase
+    .from('speakers')
+    .insert(parsed.data)
+    .select()
+    .single()
+  if (error) return res.status(400).json({ error: error.message })
+  res.status(201).json(data)
+})
+
+app.put('/api/speakers/:id', async (req, res) => {
+  const id = req.params.id
+  const parsed = speakerSchema.partial().safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request body' })
+  }
+  const { data, error } = await supabase
+    .from('speakers')
+    .update(parsed.data)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) return res.status(404).json({ error: error.message })
+  res.json(data)
+})
+
+app.delete('/api/speakers/:id', async (req, res) => {
+  const id = req.params.id
+  const { data, error } = await supabase
+    .from('speakers')
     .delete()
     .eq('id', id)
     .select()
@@ -283,6 +356,67 @@ app.post('/api/pairings/swiss', async (req, res) => {
   await supabase.from('settings').update({ currentRound: round }).eq('id', 1)
 
   res.status(201).json(inserted)
+})
+
+// ─── Rounds CRUD ───────────────────────────────────────────────────────────
+
+app.get('/api/rounds', async (_req, res) => {
+  const { data, error } = await supabase.from('rounds').select('*')
+  if (error) return res.status(500).json({ error: error.message })
+  res.json(data)
+})
+
+app.get('/api/rounds/:id', async (req, res) => {
+  const id = req.params.id
+  const { data, error } = await supabase
+    .from('rounds')
+    .select('*')
+    .eq('id', id)
+    .single()
+  if (error) return res.status(404).json({ error: error.message })
+  res.json(data)
+})
+
+app.post('/api/rounds', async (req, res) => {
+  const parsed = roundSchema.safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request body' })
+  }
+  const { data, error } = await supabase
+    .from('rounds')
+    .insert(parsed.data)
+    .select()
+    .single()
+  if (error) return res.status(400).json({ error: error.message })
+  res.status(201).json(data)
+})
+
+app.put('/api/rounds/:id', async (req, res) => {
+  const id = req.params.id
+  const parsed = roundSchema.partial().safeParse(req.body)
+  if (!parsed.success) {
+    return res.status(400).json({ error: 'Invalid request body' })
+  }
+  const { data, error } = await supabase
+    .from('rounds')
+    .update(parsed.data)
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) return res.status(404).json({ error: error.message })
+  res.json(data)
+})
+
+app.delete('/api/rounds/:id', async (req, res) => {
+  const id = req.params.id
+  const { data, error } = await supabase
+    .from('rounds')
+    .delete()
+    .eq('id', id)
+    .select()
+    .single()
+  if (error) return res.status(404).json({ error: error.message })
+  res.json(data)
 })
 
 // ─── Debates CRUD ──────────────────────────────────────────────────────────

--- a/src/components/PairingEngine.tsx
+++ b/src/components/PairingEngine.tsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
 import { usePairings, type Pairing } from '@/lib/hooks/usePairings';
+import { useRounds } from '@/lib/hooks/useRounds';
 
 const PairingEngine: React.FC = () => {
   const [pairingAlgorithm, setPairingAlgorithm] = useState<'swiss' | 'power' | 'random'>('swiss');
   const { pairings, currentRound } = usePairings();
+  const { rounds } = useRounds();
 
   return (
     <div>
-      <h2>Round {currentRound}</h2>
+      <h2>Round {currentRound} / {rounds.length}</h2>
       <select
         value={pairingAlgorithm}
         onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>

--- a/src/components/TeamRoster.tsx
+++ b/src/components/TeamRoster.tsx
@@ -8,6 +8,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Plus, Upload, Download, Search, Edit, Trash2 } from 'lucide-react';
 import { useTeams } from "@/lib/hooks/useTeams";
+import { useSpeakers } from "@/lib/hooks/useSpeakers";
 import { parseTeamsCsv, teamsToCsv, type TeamCsv } from "@/lib/csv";
 
 type Team = {
@@ -44,6 +45,7 @@ const TeamRoster = () => {
   };
 
   const { teams, addTeam, updateTeam, deleteTeam } = useTeams();
+  const { speakers: speakerList } = useSpeakers();
 
 
   const createTeam = async () => {
@@ -95,7 +97,7 @@ const TeamRoster = () => {
   );
 
   const totalTeams = teams.length;
-  const totalSpeakers = teams.reduce((acc, t) => acc + t.speakers.length, 0);
+  const totalSpeakers = speakerList.length;
   const averageTeamSize = totalTeams ? (totalSpeakers / totalTeams).toFixed(1) : '0';
 
   let universities = 0;

--- a/src/lib/hooks/useRounds.ts
+++ b/src/lib/hooks/useRounds.ts
@@ -1,0 +1,70 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '../supabase';
+
+export interface Round {
+  id: string;
+  tournament_id: string;
+  round_number: number;
+  status: string;
+}
+
+export function useRounds() {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery<Round[]>({
+    queryKey: ['rounds'],
+    queryFn: async () => {
+      const { data, error } = await supabase.from('rounds').select('*');
+      if (error) throw error;
+      return (data as Round[]) || [];
+    },
+  });
+
+  const addRound = useMutation({
+    mutationFn: async (round: Omit<Round, 'id'>) => {
+      const { data, error } = await supabase
+        .from('rounds')
+        .insert(round)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as Round;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds'] }),
+  });
+
+  const updateRound = useMutation({
+    mutationFn: async ({ id, updates }: { id: string; updates: Partial<Round> }) => {
+      const { data, error } = await supabase
+        .from('rounds')
+        .update(updates)
+        .eq('id', id)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as Round;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds'] }),
+  });
+
+  const deleteRound = useMutation({
+    mutationFn: async (id: string) => {
+      const { data, error } = await supabase
+        .from('rounds')
+        .delete()
+        .eq('id', id)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as Round;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds'] }),
+  });
+
+  return {
+    rounds: data ?? [],
+    addRound: addRound.mutateAsync,
+    updateRound: updateRound.mutateAsync,
+    deleteRound: deleteRound.mutateAsync,
+  };
+}

--- a/src/lib/hooks/useSpeakers.ts
+++ b/src/lib/hooks/useSpeakers.ts
@@ -1,0 +1,72 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '../supabase';
+
+export interface Speaker {
+  id: string;
+  team_id: string;
+  name: string;
+  position: number | null;
+}
+
+export function useSpeakers(teamId?: string) {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery<Speaker[]>({
+    queryKey: ['speakers', teamId],
+    queryFn: async () => {
+      let query = supabase.from('speakers').select('*');
+      if (teamId) query = query.eq('team_id', teamId);
+      const { data, error } = await query;
+      if (error) throw error;
+      return (data as Speaker[]) || [];
+    },
+  });
+
+  const addSpeaker = useMutation({
+    mutationFn: async (speaker: Omit<Speaker, 'id'>) => {
+      const { data, error } = await supabase
+        .from('speakers')
+        .insert(speaker)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as Speaker;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['speakers'] }),
+  });
+
+  const updateSpeaker = useMutation({
+    mutationFn: async ({ id, updates }: { id: string; updates: Partial<Speaker> }) => {
+      const { data, error } = await supabase
+        .from('speakers')
+        .update(updates)
+        .eq('id', id)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as Speaker;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['speakers'] }),
+  });
+
+  const deleteSpeaker = useMutation({
+    mutationFn: async (id: string) => {
+      const { data, error } = await supabase
+        .from('speakers')
+        .delete()
+        .eq('id', id)
+        .select()
+        .single();
+      if (error) throw error;
+      return data as Speaker;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['speakers'] }),
+  });
+
+  return {
+    speakers: data ?? [],
+    addSpeaker: addSpeaker.mutateAsync,
+    updateSpeaker: updateSpeaker.mutateAsync,
+    deleteSpeaker: deleteSpeaker.mutateAsync,
+  };
+}


### PR DESCRIPTION
## Summary
- add API routes for managing speakers and rounds
- create React hooks `useSpeakers` and `useRounds`
- use the new hooks in TeamRoster and PairingEngine

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845c7b3911883339193e57af9b1eefe