### PR TITLE
Add admin creation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "server": "node --loader ts-node/esm server/server.ts",
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.cjs"
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.cjs",
+    "create-admin": "node --loader ts-node/esm scripts/createAdmin.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/createAdmin.ts
+++ b/scripts/createAdmin.ts
@@ -1,0 +1,59 @@
+import { createClient } from '@supabase/supabase-js';
+import 'dotenv/config';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const ANON_KEY = process.env.SUPABASE_ANON_KEY;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !ANON_KEY) {
+  console.error('SUPABASE_URL and SUPABASE_ANON_KEY must be set in your environment');
+  process.exit(1);
+}
+
+const client = createClient(SUPABASE_URL, SERVICE_KEY || ANON_KEY);
+
+async function main() {
+  const email = 'admin@luis.martin';
+  const password = 'sa1965';
+
+  let userId: string | undefined;
+
+  if (SERVICE_KEY) {
+    const { data, error } = await client.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    });
+    if (error || !data.user) {
+      console.error('Failed to create auth user:', error?.message);
+      process.exit(1);
+    }
+    userId = data.user.id;
+  } else {
+    const { data, error } = await client.auth.signUp({ email, password });
+    if (error || !data.user) {
+      console.error('Failed to sign up user:', error?.message);
+      process.exit(1);
+    }
+    userId = data.user.id;
+  }
+
+  const { error: insertError } = await client.from('users').insert({
+    id: userId,
+    email,
+    role: 'admin',
+    name: 'Admin User',
+  });
+
+  if (insertError) {
+    console.error('Failed to insert user row:', insertError.message);
+    process.exit(1);
+  }
+
+  console.log(`Admin user ${email} created`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a `create-admin` script that signs up a new admin user
- wire the script into package.json

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845c828e50483339abe98feacc0d8bf