### PR TITLE
Add docs for admin credentials

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
-
 VITE_API_BASE_URL=http://localhost:3001
-SUPABASE_URL=https://placeholder.supabase.co
-SUPABASE_ANON_KEY=placeholder-anon-key
-VITE_SUPABASE_URL=https://placeholder.supabase.co
-VITE_SUPABASE_ANON_KEY=placeholder-anon-key
+SUPABASE_URL=https://your-supabase-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+VITE_SUPABASE_URL=https://your-supabase-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ DebateMinistrator is a modern, web-based platform designed to streamline the end
 2. In your project's **Settings → API** section copy the **Project URL** and **Anon public key**.
 3. Paste those values into the corresponding variables in your `.env` file as shown above.
 4. Ensure these variables are available when starting the API server or the frontend. The backend will exit with an error if `SUPABASE_URL` or `SUPABASE_ANON_KEY` is missing.
+5. See [docs/credentials.md](docs/credentials.md) for the default admin login and a list of required environment variables. These must be configured before running `npm run create-admin`.
 
 3. **Start the development server:**
    ```bash

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,22 @@
+# Admin Credentials and Supabase Environment
+
+The initial admin user credentials are:
+
+- **Email:** `admin@luis.martin`
+- **Password:** `sa1965`
+
+These credentials are required when running the setup script:
+
+```bash
+npm run create-admin
+```
+
+Ensure the following environment variables are configured in your `.env` file before executing this command:
+
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY` (optional)
+
+The values should correspond to your Supabase project. See the README for details on obtaining them.


### PR DESCRIPTION
## Summary
- update `.env` with Supabase placeholders
- document admin credentials in `docs/credentials.md`
- reference the new credentials doc in README

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Test Suites: 4 failed)*


------
https://chatgpt.com/codex/tasks/task_e_6845ce0d81dc8333a3d003e08e2b59be