### PR TITLE
Fix admin email in seed data

### DIFF
--- a/server/db.json
+++ b/server/db.json
@@ -55,7 +55,7 @@
     {
       "id": 1,
       "name": "Admin",
-      "email": "admin@example.com",
+      "email": "admin@luis.martin",
       "role": "Judge"
     }
   ]

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -2,7 +2,7 @@
 -- Inserts an admin user placeholder
 
 INSERT INTO public.users (id, email, role, name)
-VALUES ('00000000-0000-0000-0000-000000000001', 'admin@example.com', 'admin', 'Admin User')
+VALUES ('00000000-0000-0000-0000-000000000001', 'admin@luis.martin', 'admin', 'Admin User')
 ON CONFLICT DO NOTHING;
 
 -- Initialize settings with round 1


### PR DESCRIPTION
## Summary
- seed the admin user with `admin@luis.martin`
- update the local db example with the same email

## Testing
- `npm run lint`
- `npm test --silent` *(fails: 13 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845d237303083338f3ee4bc02fb055e