### PR TITLE
Improve login page design and env checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ DebateMinistrator is a modern, web-based platform designed to streamline the end
 3. Paste those values into the corresponding variables in your `.env` file as shown above.
 4. Ensure these variables are available when starting the API server or the frontend. The backend will exit with an error if `SUPABASE_URL` or `SUPABASE_ANON_KEY` is missing.
 5. See [docs/credentials.md](docs/credentials.md) for the default admin login and a list of required environment variables. These must be configured before running `npm run create-admin`.
+6. The login and signup pages also depend on `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`. If these variables are missing, you'll see a setup prompt (the `AuthFallback` component) instead of the forms.
 
 ### Creating the Admin User
 

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,12 +1,40 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useNavigate, Link } from 'react-router-dom'
+import AuthFallback from '@/components/AuthFallback'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Lock } from 'lucide-react'
 
 export default function SignIn() {
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [hasSupabaseConfig, setHasSupabaseConfig] = useState(true)
+
+  useEffect(() => {
+    const supabaseUrl =
+      process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL
+    const supabaseKey =
+      process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+
+    if (
+      !supabaseUrl ||
+      !supabaseKey ||
+      supabaseUrl.includes('your-project') ||
+      supabaseKey.includes('your-anon-key')
+    ) {
+      setHasSupabaseConfig(false)
+    }
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -15,16 +43,45 @@ export default function SignIn() {
     else navigate('/')
   }
 
+  if (!hasSupabaseConfig) return <AuthFallback />
+
   return (
-    <div className="container mx-auto py-10">
-      <h1 className="text-2xl font-bold mb-4">Sign In</h1>
-      {error && <p className="text-red-600">{error}</p>}
-      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
-        <input className="border p-2 w-full" type="email" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
-        <input className="border p-2 w-full" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
-        <button className="bg-blue-600 text-white px-4 py-2" type="submit">Sign In</button>
-      </form>
-      <p className="mt-4">Don't have an account? <Link to="/signup" className="text-blue-600">Sign up</Link></p>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+            <Lock className="w-6 h-6 text-blue-600" />
+          </div>
+          <CardTitle>Sign In</CardTitle>
+          <CardDescription>Access your DebateMinistrator account</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && <p className="text-red-600 text-sm text-center">{error}</p>}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <Input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <Button className="w-full" type="submit">
+              Sign In
+            </Button>
+          </form>
+          <p className="text-sm text-center">
+            Don't have an account?{' '}
+            <Link to="/signup" className="text-blue-600">
+              Sign up
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,12 +1,40 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useNavigate, Link } from 'react-router-dom'
+import AuthFallback from '@/components/AuthFallback'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { UserPlus } from 'lucide-react'
 
 export default function SignUp() {
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [hasSupabaseConfig, setHasSupabaseConfig] = useState(true)
+
+  useEffect(() => {
+    const supabaseUrl =
+      process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL
+    const supabaseKey =
+      process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+
+    if (
+      !supabaseUrl ||
+      !supabaseKey ||
+      supabaseUrl.includes('your-project') ||
+      supabaseKey.includes('your-anon-key')
+    ) {
+      setHasSupabaseConfig(false)
+    }
+  }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -15,16 +43,45 @@ export default function SignUp() {
     else navigate('/')
   }
 
+  if (!hasSupabaseConfig) return <AuthFallback />
+
   return (
-    <div className="container mx-auto py-10">
-      <h1 className="text-2xl font-bold mb-4">Sign Up</h1>
-      {error && <p className="text-red-600">{error}</p>}
-      <form onSubmit={handleSubmit} className="space-y-4 max-w-sm">
-        <input className="border p-2 w-full" type="email" placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
-        <input className="border p-2 w-full" type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
-        <button className="bg-blue-600 text-white px-4 py-2" type="submit">Sign Up</button>
-      </form>
-      <p className="mt-4">Already have an account? <Link to="/signin" className="text-blue-600">Sign in</Link></p>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center">
+            <UserPlus className="w-6 h-6 text-blue-600" />
+          </div>
+          <CardTitle>Sign Up</CardTitle>
+          <CardDescription>Create your DebateMinistrator account</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && <p className="text-red-600 text-sm text-center">{error}</p>}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <Input
+              type="email"
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+            <Input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <Button className="w-full" type="submit">
+              Sign Up
+            </Button>
+          </form>
+          <p className="text-sm text-center">
+            Already have an account?{' '}
+            <Link to="/signin" className="text-blue-600">
+              Sign in
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/src/pages/__tests__/AuthPages.test.tsx
+++ b/src/pages/__tests__/AuthPages.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: jest.fn(),
+      signUp: jest.fn(),
+    },
+  },
+  __esModule: true,
+}))
+
+import SignIn from '../SignIn'
+import SignUp from '../SignUp'
+
+describe('Auth pages configuration checks', () => {
+  const ORIGINAL_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('shows AuthFallback on SignIn when env vars missing', () => {
+    delete process.env.VITE_SUPABASE_URL
+    delete process.env.VITE_SUPABASE_ANON_KEY
+    render(<SignIn />)
+    expect(screen.getByText(/Setup Required/i)).toBeInTheDocument()
+  })
+
+  it('shows AuthFallback on SignUp when env vars missing', () => {
+    delete process.env.VITE_SUPABASE_URL
+    delete process.env.VITE_SUPABASE_ANON_KEY
+    render(<SignUp />)
+    expect(screen.getByText(/Setup Required/i)).toBeInTheDocument()
+  })
+
+  it('renders forms when env vars are present', () => {
+    process.env.VITE_SUPABASE_URL = 'https://example.supabase.co'
+    process.env.VITE_SUPABASE_ANON_KEY = 'key'
+    render(<SignIn />)
+    expect(screen.getByText(/Sign In/i)).toBeInTheDocument()
+  })
+})

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -2,7 +2,7 @@
 -- Inserts an admin user placeholder
 
 INSERT INTO public.users (id, email, role, name)
-VALUES ('00000000-0000-0000-0000-000000000001', 'admin@example.com', 'admin', 'Admin User')
+VALUES ('00000000-0000-0000-0000-000000000001', 'admin@luis.martin', 'admin', 'Admin User')
 ON CONFLICT DO NOTHING;
 
 -- Initialize settings with round 1


### PR DESCRIPTION
## Summary
- enhance SignIn/SignUp pages with Card-based UI
- show `AuthFallback` when Supabase env vars missing
- add tests for login pages' env checks
- update seed email to `admin@luis.martin`
- note login requirements in README

## Testing
- `npm run lint`
- `npm test --silent` *(fails: TypeScript errors in server tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845d00484148333b70614e05d886439