### PR TITLE
Improve README Supabase login clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ DebateMinistrator is a modern, web-based platform designed to streamline the end
 2. In your project's **Settings → API** section copy the **Project URL** and **Anon public key**.
 3. Paste those values into the corresponding variables in your `.env` file as shown above.
 4. Ensure these variables are available when starting the API server or the frontend. The backend will exit with an error if `SUPABASE_URL` or `SUPABASE_ANON_KEY` is missing.
-5. See [docs/credentials.md](docs/credentials.md) for the default admin login and a list of required environment variables. These must be configured before running `npm run create-admin`.
+5. Sign In and Sign Up only work when `SUPABASE_URL` and `SUPABASE_ANON_KEY` are valid. If either variable is missing or still contains placeholder values, the application shows the **AuthFallback** screen instead of the login forms.
+6. See [docs/credentials.md](docs/credentials.md) for the default admin login and a list of required environment variables. These must be configured before running `npm run create-admin`.
 
 ### Creating the Admin User
 

--- a/src/lib/pairing/config.ts
+++ b/src/lib/pairing/config.ts
@@ -22,7 +22,7 @@ export async function loadConstraintSettings(): Promise<ConstraintSettings> {
   try {
     // Fetch typed rows from the database
     const { data, error } = await supabase
-      .from<ConstraintRow>('constraint_settings')
+      .from('constraint_settings')
       .select('name, enabled')
 
     if (error) {
@@ -35,8 +35,10 @@ export async function loadConstraintSettings(): Promise<ConstraintSettings> {
     // Start with the default JSON configuration
     const cfg: ConstraintSettings = { ...(defaultConfig as ConstraintSettings) }
 
+    const rows = data as ConstraintRow[]
+
     // Merge any overrides from the database
-    for (const row of data) {
+    for (const row of rows) {
       if (row.name in cfg) {
         cfg[row.name] = row.enabled
       }


### PR DESCRIPTION
## Summary
- mention that Sign In/Sign Up require SUPABASE_URL and SUPABASE_ANON_KEY
- fix Supabase query types used in `loadConstraintSettings`

## Testing
- `npm run lint` *(passes with warnings)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845d23c787883338e3f7b3ceea8067e