### PR TITLE
Add Supabase config check to auth pages

### DIFF
--- a/src/lib/pairing/config.ts
+++ b/src/lib/pairing/config.ts
@@ -22,7 +22,7 @@ export async function loadConstraintSettings(): Promise<ConstraintSettings> {
   try {
     // Fetch typed rows from the database
     const { data, error } = await supabase
-      .from<ConstraintRow>('constraint_settings')
+      .from('constraint_settings')
       .select('name, enabled')
 
     if (error) {

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useNavigate, Link } from 'react-router-dom'
+import AuthFallback from '@/components/AuthFallback'
 
 export default function SignIn() {
   const navigate = useNavigate()
@@ -8,12 +9,22 @@ export default function SignIn() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
 
+  const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL
+  const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+  const hasSupabaseConfig =
+    !!supabaseUrl &&
+    !!supabaseKey &&
+    !supabaseUrl.includes('your-project') &&
+    !supabaseKey.includes('your-anon-key')
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const { error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) setError(error.message)
     else navigate('/')
   }
+
+  if (!hasSupabaseConfig) return <AuthFallback />
 
   return (
     <div className="container mx-auto py-10">

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useNavigate, Link } from 'react-router-dom'
+import AuthFallback from '@/components/AuthFallback'
 
 export default function SignUp() {
   const navigate = useNavigate()
@@ -8,12 +9,22 @@ export default function SignUp() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
 
+  const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL
+  const supabaseKey = process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY
+  const hasSupabaseConfig =
+    !!supabaseUrl &&
+    !!supabaseKey &&
+    !supabaseUrl.includes('your-project') &&
+    !supabaseKey.includes('your-anon-key')
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const { error } = await supabase.auth.signUp({ email, password })
     if (error) setError(error.message)
     else navigate('/')
   }
+
+  if (!hasSupabaseConfig) return <AuthFallback />
 
   return (
     <div className="container mx-auto py-10">


### PR DESCRIPTION
## Summary
- show setup instructions in Sign In/Sign Up when Supabase isn't configured
- remove an invalid type parameter from `loadConstraintSettings` that caused ts-jest failures

## Testing
- `npm run lint`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6845d231997c833398aebeb78bacd0f6