### PR TITLE
Show demo mode when Supabase config missing

### DIFF
--- a/__mocks__/supabase-js.js
+++ b/__mocks__/supabase-js.js
@@ -1,0 +1,15 @@
+export const createClient = () => ({
+  auth: {
+    signInWithPassword: () => Promise.resolve({}),
+    signUp: () => Promise.resolve({}),
+    onAuthStateChange: () => ({ data: { subscription: { unsubscribe() {} } } }),
+    getSession: () => Promise.resolve({ data: { session: null } }),
+  },
+  from: () => ({
+    select: () => Promise.resolve({ data: [] }),
+    insert: () => Promise.resolve({}),
+    update: () => Promise.resolve({}),
+    delete: () => Promise.resolve({}),
+  }),
+});
+export default { createClient };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,7 +5,8 @@ module.exports = {
   testEnvironment: 'jsdom',
 
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1'
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@supabase/supabase-js$': '<rootDir>/__mocks__/supabase-js.js'
   },
 
   setupFiles: ['<rootDir>/jest.polyfill.ts'],
@@ -14,7 +15,7 @@ module.exports = {
   testPathIgnorePatterns: ['/node_modules/', '/dist/', '/src/components/__tests__/'],
 
   transformIgnorePatterns: [
-    '/node_modules/(?!(?:@supabase)/)'
+    '/node_modules/'
   ],
 
   extensionsToTreatAsEsm: ['.ts', '.tsx'],

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -2,7 +2,7 @@
 import { Navigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'
-import AuthFallback from './AuthFallback'
+import DemoMode from './DemoMode'
 
 export default function ProtectedRoute({ children }: { children: JSX.Element }) {
   const [loading, setLoading] = useState(true)
@@ -37,7 +37,7 @@ export default function ProtectedRoute({ children }: { children: JSX.Element }) 
   }, [])
 
   if (loading) return <div className="min-h-screen flex items-center justify-center">Loading...</div>
-  if (!hasSupabaseConfig) return <AuthFallback />
+  if (!hasSupabaseConfig) return <DemoMode />
   if (!session) return <Navigate to="/signin" replace />
   return children
 }

--- a/src/pages/__tests__/AuthPages.test.tsx
+++ b/src/pages/__tests__/AuthPages.test.tsx
@@ -10,6 +10,23 @@ jest.mock('@/lib/supabase', () => ({
   __esModule: true,
 }))
 
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    auth: {
+      signInWithPassword: jest.fn(),
+      signUp: jest.fn(),
+      onAuthStateChange: jest.fn(() => ({ data: { subscription: { unsubscribe: jest.fn() } } })),
+      getSession: jest.fn(() => Promise.resolve({ data: { session: null } })),
+    },
+    from: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    insert: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+  }),
+  __esModule: true,
+}))
+
 import SignIn from '../SignIn'
 import SignUp from '../SignUp'
 


### PR DESCRIPTION
## Summary
- render DemoMode when Supabase credentials are not configured
- add stub for `@supabase/supabase-js` and map it in Jest config
- update auth tests to mock `@supabase/supabase-js`

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Jest could not run all tests due to environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_6845d59bd7bc83338f9071fde2210b70