### PR TITLE
Fix test mocks and ensure test suite passes

### DIFF
--- a/__mocks__/supabase-js.js
+++ b/__mocks__/supabase-js.js
@@ -1,3 +1,15 @@
+let mockData = {};
+export function __setMockData(data) {
+  mockData = data;
+}
+
+const makeThenable = result => {
+  const promise = Promise.resolve(result);
+  return {
+    then: (res, rej) => promise.then(res, rej),
+  };
+};
+
 export const createClient = () => ({
   auth: {
     signInWithPassword: () => Promise.resolve({}),
@@ -5,11 +17,54 @@ export const createClient = () => ({
     onAuthStateChange: () => ({ data: { subscription: { unsubscribe() {} } } }),
     getSession: () => Promise.resolve({ data: { session: null } }),
   },
-  from: () => ({
-    select: () => Promise.resolve({ data: [] }),
-    insert: () => Promise.resolve({}),
-    update: () => Promise.resolve({}),
-    delete: () => Promise.resolve({}),
+  from: table => ({
+    select: () => {
+      const result = { data: mockData[table] || [], error: null };
+      const promise = makeThenable(result);
+      promise.eq = (field, value) => {
+        const records = (mockData[table] || []).filter(r => r[field] === value);
+        const eqRes = { data: records, error: null };
+        const eqPromise = makeThenable(eqRes);
+        eqPromise.single = () => Promise.resolve({ data: records[0] || null, error: null });
+        return eqPromise;
+      };
+      promise.single = () => Promise.resolve({ data: (mockData[table] || [])[0] || null, error: null });
+      return promise;
+    },
+    insert: values => {
+      const arr = Array.isArray(values) ? values : [values];
+      const inserted = arr.map(v => ({ id: Date.now(), ...v }));
+      mockData[table] = (mockData[table] || []).concat(inserted);
+      const result = { data: Array.isArray(values) ? inserted : inserted[0], error: null };
+      return {
+        select: () => {
+          const promise = makeThenable(result);
+          promise.single = () => Promise.resolve(result);
+          return promise;
+        },
+      };
+    },
+    update: values => ({
+      eq: (field, value) => {
+        const idx = (mockData[table] || []).findIndex(r => r[field] === value);
+        if (idx !== -1) mockData[table][idx] = { ...mockData[table][idx], ...values };
+        const updated = { data: mockData[table][idx] || null, error: null };
+        const promise = makeThenable(updated);
+        promise.select = () => ({ single: () => Promise.resolve(updated) });
+        return promise;
+      },
+    }),
+    delete: () => ({
+      eq: (field, value) => ({
+        select: () => ({
+          single: () => {
+            const idx = (mockData[table] || []).findIndex(r => r[field] === value);
+            const removed = idx !== -1 ? mockData[table].splice(idx, 1)[0] : null;
+            return Promise.resolve({ data: removed, error: null });
+          },
+        }),
+      }),
+    }),
   }),
 });
-export default { createClient };
+export default { createClient, __setMockData };

--- a/server/__tests__/analytics.test.ts
+++ b/server/__tests__/analytics.test.ts
@@ -1,8 +1,8 @@
 /** @jest-environment node */
 import request from 'supertest';
 import type { Express } from 'express';
-import { createClient } from '@supabase/supabase-js';
-import { jest } from '@jest/globals';
+// @ts-expect-error - provided by Jest mock
+import { __setMockData } from '@supabase/supabase-js';
 
 const seed = {
   teams: [
@@ -25,60 +25,6 @@ const seed = {
 };
 let data: any = JSON.parse(JSON.stringify(seed));
 
-jest.mock('@supabase/supabase-js', () => {
-  const makeThenable = (result: any) => ({
-    then: (res: any, rej: any) => Promise.resolve(result).then(res, rej)
-  });
-  return {
-    createClient: () => ({
-      from: (table: string) => ({
-        select: () => {
-          const promise: any = makeThenable({ data: data[table], error: null });
-          promise.eq = (field: string, value: any) => {
-            const records = data[table].filter((r: any) => r[field] === value);
-            const eqPromise: any = makeThenable({ data: records, error: null });
-            eqPromise.single = () => Promise.resolve({ data: records[0] || null, error: null });
-            return eqPromise;
-          };
-          promise.single = () => Promise.resolve({ data: data[table][0] || null, error: null });
-          return promise;
-        },
-        insert: (values: any) => {
-          const arr = Array.isArray(values) ? values : [values];
-          const inserted = arr.map(v => ({ id: Date.now(), ...v }));
-          data[table].push(...inserted);
-          return {
-            select: () =>
-              Promise.resolve({ data: inserted, error: null })
-          };
-        },
-        update: (values: any) => ({
-          eq: (field: string, value: any) => {
-            const doUpdate = () => {
-              const idx = data[table].findIndex((r: any) => r[field] === value);
-              if (idx !== -1) data[table][idx] = { ...data[table][idx], ...values };
-              return { data: data[table][idx] || null, error: null };
-            };
-            const promise: any = makeThenable(doUpdate());
-            promise.select = () => ({ single: () => Promise.resolve(doUpdate()) });
-            return promise;
-          }
-        }),
-        delete: () => ({
-          eq: (field: string, value: any) => ({
-            select: () => ({
-              single: () => {
-                const idx = data[table].findIndex((r: any) => r[field] === value);
-                const removed = idx !== -1 ? data[table].splice(idx, 1)[0] : null;
-                return Promise.resolve({ data: removed, error: null });
-              }
-            })
-          })
-        })
-      })
-    })
-  };
-});
 
 let app: Express;
 beforeAll(async () => {
@@ -90,6 +36,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   data = JSON.parse(JSON.stringify(seed));
+  __setMockData(data);
 });
 
 describe('Analytics endpoints', () => {

--- a/server/__tests__/rounds.test.ts
+++ b/server/__tests__/rounds.test.ts
@@ -1,8 +1,8 @@
 /** @jest-environment node */
 import request from 'supertest';
 import type { Express } from 'express';
-import { createClient } from '@supabase/supabase-js';
-import { jest } from '@jest/globals';
+// @ts-expect-error - provided by Jest mock
+import { __setMockData } from '@supabase/supabase-js';
 
 const seed = {
   teams: [
@@ -21,59 +21,6 @@ const seed = {
 };
 let data: any = JSON.parse(JSON.stringify(seed));
 
-jest.mock('@supabase/supabase-js', () => {
-  const makeThenable = (result: any) => ({
-    then: (res: any, rej: any) => Promise.resolve(result).then(res, rej)
-  });
-  return {
-    createClient: () => ({
-      from: (table: string) => ({
-        select: () => {
-          const promise: any = makeThenable({ data: data[table], error: null });
-          promise.eq = (field: string, value: any) => {
-            const records = data[table].filter((r: any) => r[field] === value);
-            const eqPromise: any = makeThenable({ data: records, error: null });
-            eqPromise.single = () => Promise.resolve({ data: records[0] || null, error: null });
-            return eqPromise;
-          };
-          promise.single = () => Promise.resolve({ data: data[table][0] || null, error: null });
-          return promise;
-        },
-        insert: (values: any) => {
-          const arr = Array.isArray(values) ? values : [values];
-          const inserted = arr.map(v => ({ id: Date.now(), ...v }));
-          data[table].push(...inserted);
-          return {
-            select: () => Promise.resolve({ data: inserted, error: null })
-          };
-        },
-        update: (values: any) => ({
-          eq: (field: string, value: any) => {
-            const doUpdate = () => {
-              const idx = data[table].findIndex((r: any) => r[field] === value);
-              if (idx !== -1) data[table][idx] = { ...data[table][idx], ...values };
-              return { data: data[table][idx] || null, error: null };
-            };
-            const promise: any = makeThenable(doUpdate());
-            promise.select = () => ({ single: () => Promise.resolve(doUpdate()) });
-            return promise;
-          }
-        }),
-        delete: () => ({
-          eq: (field: string, value: any) => ({
-            select: () => ({
-              single: () => {
-                const idx = data[table].findIndex((r: any) => r[field] === value);
-                const removed = idx !== -1 ? data[table].splice(idx, 1)[0] : null;
-                return Promise.resolve({ data: removed, error: null });
-              }
-            })
-          })
-        })
-      })
-    })
-  };
-});
 
 let app: Express;
 beforeAll(async () => {
@@ -85,6 +32,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   data = JSON.parse(JSON.stringify(seed));
+  __setMockData(data);
 });
 
 describe('Swiss pairing rounds', () => {


### PR DESCRIPTION
## Summary
- implement smarter Supabase mock used across tests
- set mock data in test setup and remove ad-hoc mocks

## Testing
- `npm test --silent`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845d83532e48333a6de6200e99e0403