### PR TITLE
Rename hasSupabaseConfig helper

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,7 +1,7 @@
 
 import { Navigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import { supabase, hasSupabaseConfig } from '@/lib/supabase'
+import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import DemoMode from './DemoMode'
 
 export default function ProtectedRoute({ children }: { children: JSX.Element }) {
@@ -12,7 +12,7 @@ export default function ProtectedRoute({ children }: { children: JSX.Element }) 
   useEffect(() => {
     // Verify Supabase configuration once on mount. If invalid, show demo mode
     // rather than attempting auth calls that will fail.
-    if (!hasSupabaseConfig()) {
+    if (!isSupabaseConfigured()) {
       setHasConfig(false)
       setLoading(false)
       return

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -29,7 +29,7 @@ export function getSupabaseConfig() {
  * Determine if the Supabase configuration appears valid. This is used by the
  * auth pages to decide whether to display the setup instructions.
  */
-export function hasSupabaseConfig() {
+export function isSupabaseConfigured() {
   const { url, anonKey } = getSupabaseConfig()
 
   if (!url || !anonKey) return false

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { supabase, hasSupabaseConfig } from '@/lib/supabase'
+import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import { useNavigate, Link } from 'react-router-dom'
 import AuthFallback from '@/components/AuthFallback'
 import {
@@ -23,7 +23,7 @@ export default function SignIn() {
   useEffect(() => {
     // Evaluate Supabase configuration once on mount. This covers local dev,
     // production builds, and serverless platforms.
-    setHasConfig(hasSupabaseConfig())
+    setHasConfig(isSupabaseConfigured())
   }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { supabase, hasSupabaseConfig } from '@/lib/supabase'
+import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import { useNavigate, Link } from 'react-router-dom'
 import AuthFallback from '@/components/AuthFallback'
 import {
@@ -23,7 +23,7 @@ export default function SignUp() {
   useEffect(() => {
     // Evaluate Supabase configuration once on mount. This covers local dev,
     // production builds, and serverless platforms.
-    setHasConfig(hasSupabaseConfig())
+    setHasConfig(isSupabaseConfigured())
   }, [])
 
   const handleSubmit = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- rename `hasSupabaseConfig()` to `isSupabaseConfigured()`
- update auth pages and `ProtectedRoute` imports
- keep Supabase client export the same

## Testing
- `npm run lint`
- `npm test --silent` *(fails: TypeError in server tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845dd4f972483338c10151ac5045358