### PR TITLE
Define SupabaseConfig interface

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,11 @@
 
 import { createClient } from '@supabase/supabase-js'
 
+export interface SupabaseConfig {
+  url?: string
+  anonKey?: string
+}
+
 /**
  * Resolve Supabase configuration from whatever environment we're running in.
  *
@@ -8,7 +13,7 @@ import { createClient } from '@supabase/supabase-js'
  * - `process.env` is used for Node/Jest environments and when running on
  *   platforms like Vercel/Netlify which expose runtime env vars.
  */
-export function getSupabaseConfig() {
+export function getSupabaseConfig(): SupabaseConfig {
   const meta = typeof import.meta !== 'undefined' ? import.meta : undefined
   const env = (meta?.env ?? {}) as Record<string, string | undefined>
 


### PR DESCRIPTION
## Summary
- define `SupabaseConfig` interface in `src/lib/supabase.ts`
- type `getSupabaseConfig` to return `SupabaseConfig`

## Testing
- `npm run lint`
- `npm test --silent` *(fails: TypeError from supabase calls, worker process exited)*

------
https://chatgpt.com/codex/tasks/task_e_6845dd50dfcc8333ad7a176ed3d4e854