### PR TITLE
Update install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ DebateMinistrator is a modern, web-based platform designed to streamline the end
    ```bash
    npm install
    ```
-   Make sure to run this before executing `npm run lint`.
+   This installs **all** required packages, including development
+   dependencies. A full install is necessary before running `npm run lint`
+   or any TypeScript build scripts.
 
 ### Environment Variables
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "preview": "vite preview",
     "server": "node --loader ts-node/esm server/server.ts",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.cjs",
-    "create-admin": "node --loader ts-node/esm scripts/createAdmin.ts"
+    "create-admin": "node --loader ts-node/esm scripts/createAdmin.ts",
+    "postinstall": "echo 'Dependencies installed. Run npm test --silent and npm run lint before committing.'"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",


### PR DESCRIPTION
## Summary
- clarify that full dependency installation is needed to run lint and TypeScript builds
- add a postinstall hint for contributors

## Testing
- `npm test --silent` *(fails: TypeError in analytics and server tests)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845dd53b3d483339cf0792ead729006