### PR TITLE
Simplify Supabase config handling

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -41,6 +41,13 @@ export function hasSupabaseConfig() {
   )
 }
 
+/**
+ * Alias of `hasSupabaseConfig` for clarity when used in components.
+ */
+export function isSupabaseConfigured() {
+  return hasSupabaseConfig()
+}
+
 // Create client even with placeholder values so imports succeed during testing
 const { url: SUPABASE_URL, anonKey: SUPABASE_ANON_KEY } = getSupabaseConfig()
 export const supabase = createClient(

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { supabase, hasSupabaseConfig } from '@/lib/supabase'
+import { useState } from 'react'
+import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import { useNavigate, Link } from 'react-router-dom'
 import AuthFallback from '@/components/AuthFallback'
 import {
@@ -18,13 +18,7 @@ export default function SignIn() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
-  const [hasConfig, setHasConfig] = useState(true)
-
-  useEffect(() => {
-    // Evaluate Supabase configuration once on mount. This covers local dev,
-    // production builds, and serverless platforms.
-    setHasConfig(hasSupabaseConfig())
-  }, [])
+  const hasConfig = isSupabaseConfigured()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
-import { supabase, hasSupabaseConfig } from '@/lib/supabase'
+import { useState } from 'react'
+import { supabase, isSupabaseConfigured } from '@/lib/supabase'
 import { useNavigate, Link } from 'react-router-dom'
 import AuthFallback from '@/components/AuthFallback'
 import {
@@ -18,13 +18,7 @@ export default function SignUp() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
-  const [hasConfig, setHasConfig] = useState(true)
-
-  useEffect(() => {
-    // Evaluate Supabase configuration once on mount. This covers local dev,
-    // production builds, and serverless platforms.
-    setHasConfig(hasSupabaseConfig())
-  }, [])
+  const hasConfig = isSupabaseConfigured()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()


### PR DESCRIPTION
## Summary
- expose `isSupabaseConfigured` helper
- simplify SignIn and SignUp configuration checks

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Analytics and rounds API tests)*

------
https://chatgpt.com/codex/tasks/task_e_6845dd5485088333b47d90ce4402a437