### PR TITLE
Refactor server to reuse supabase config helper

### DIFF
--- a/server/__tests__/rounds.test.ts
+++ b/server/__tests__/rounds.test.ts
@@ -43,9 +43,9 @@ jest.mock('@supabase/supabase-js', () => {
           const arr = Array.isArray(values) ? values : [values];
           const inserted = arr.map(v => ({ id: Date.now(), ...v }));
           data[table].push(...inserted);
-          return {
-            select: () => Promise.resolve({ data: inserted, error: null })
-          };
+          const promise: any = makeThenable({ data: inserted, error: null });
+          promise.single = () => Promise.resolve({ data: inserted[0], error: null });
+          return { select: () => promise };
         },
         update: (values: any) => ({
           eq: (field: string, value: any) => {
@@ -55,7 +55,11 @@ jest.mock('@supabase/supabase-js', () => {
               return { data: data[table][idx] || null, error: null };
             };
             const promise: any = makeThenable(doUpdate());
-            promise.select = () => ({ single: () => Promise.resolve(doUpdate()) });
+            promise.select = () => {
+              const p: any = makeThenable(doUpdate());
+              p.single = () => Promise.resolve(doUpdate());
+              return p;
+            };
             return promise;
           }
         }),

--- a/server/__tests__/server.test.ts
+++ b/server/__tests__/server.test.ts
@@ -53,12 +53,9 @@ jest.mock('@supabase/supabase-js', () => {
           const arr = Array.isArray(values) ? values : [values];
           const inserted = arr.map(v => ({ id: Date.now(), ...v }));
           data[table].push(...inserted);
-          return {
-            select: () => ({
-              single: () =>
-                Promise.resolve({ data: inserted[0], error: null }),
-            }),
-          };
+          const promise: any = makeThenable({ data: inserted, error: null });
+          promise.single = () => Promise.resolve({ data: inserted[0], error: null });
+          return { select: () => promise };
         },
         update: (values: any) => ({
           eq: (field: string, value: any) => {
@@ -68,7 +65,11 @@ jest.mock('@supabase/supabase-js', () => {
               return { data: data[table][idx] || null, error: null };
             };
             const promise: any = makeThenable(doUpdate());
-            promise.select = () => ({ single: () => Promise.resolve(doUpdate()) });
+            promise.select = () => {
+              const p: any = makeThenable(doUpdate());
+              p.single = () => Promise.resolve(doUpdate());
+              return p;
+            };
             return promise;
           },
         }),

--- a/server/server.ts
+++ b/server/server.ts
@@ -6,6 +6,7 @@ import { z } from 'zod'
 import { registerAnalyticsRoutes } from './analytics'
 import { generateEliminationBracket, updateBracketWithResults } from './pairing/bracket'
 import { generateSwissPairings } from './pairing/swiss'
+import { getSupabaseConfig, hasSupabaseConfig } from '../src/lib/supabase'
 
 const app = express()
 app.use(cors())
@@ -13,24 +14,18 @@ app.use(express.json())
 
 // ─── Supabase Client ───────────────────────────────────────────────────────
 
-let SUPABASE_URL = process.env.SUPABASE_URL as string | undefined
-let SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY as string | undefined
-let isSupabaseConfigured = true
+let { url: SUPABASE_URL, anonKey: SUPABASE_ANON_KEY } = getSupabaseConfig()
+let isSupabaseConfigured = hasSupabaseConfig()
 
-if (
-  !SUPABASE_URL ||
-  !SUPABASE_ANON_KEY ||
-  SUPABASE_URL.includes('placeholder') ||
-  SUPABASE_ANON_KEY.includes('placeholder')
-) {
+if (!isSupabaseConfigured) {
   if (process.env.NODE_ENV === 'test') {
     SUPABASE_URL = 'http://localhost'
     SUPABASE_ANON_KEY = 'anon'
+    isSupabaseConfigured = true
   } else {
     console.warn('⚠️  Supabase not configured - API will return mock data')
-    isSupabaseConfigured = false
-    SUPABASE_URL = 'https://placeholder.supabase.co'
-    SUPABASE_ANON_KEY = 'placeholder-key'
+    SUPABASE_URL = SUPABASE_URL || 'https://placeholder.supabase.co'
+    SUPABASE_ANON_KEY = SUPABASE_ANON_KEY || 'placeholder-key'
   }
 }
 


### PR DESCRIPTION
## Summary
- reuse shared `getSupabaseConfig` and `hasSupabaseConfig` in server
- fix supabase mocks in tests to support chained `select()` calls

## Testing
- `npm test --silent` *(fails: supabase.from(...).insert(...).select is not a function)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845dd55bb3083338cc982b4c9d433c4