### PR TITLE
Refine supabase config test types

### DIFF
--- a/src/lib/__tests__/supabaseConfig.test.ts
+++ b/src/lib/__tests__/supabaseConfig.test.ts
@@ -1,13 +1,19 @@
 // src/lib/supabase/hasConfig.test.ts
 import { hasSupabaseConfig } from '../supabase'
 
+interface MutableImportMeta extends ImportMeta {
+  env: Record<string, string | undefined>
+}
+
+const importMeta = import.meta as unknown as MutableImportMeta
+
 describe('hasSupabaseConfig', () => {
   const originalProcessEnv = { ...process.env }
-  const originalImportMetaEnv = { ...(import.meta as any).env }
+  const originalImportMetaEnv = { ...importMeta.env }
 
   beforeEach(() => {
     // Clear both Vite and Node envs
-    ;(import.meta as any).env = {}
+    importMeta.env = {}
     delete process.env.VITE_SUPABASE_URL
     delete process.env.VITE_SUPABASE_ANON_KEY
     delete process.env.SUPABASE_URL
@@ -16,12 +22,12 @@ describe('hasSupabaseConfig', () => {
 
   afterEach(() => {
     // Restore originals
-    ;(import.meta as any).env = originalImportMetaEnv
+    importMeta.env = originalImportMetaEnv
     process.env = { ...originalProcessEnv }
   })
 
   it('returns true when valid VITE_ and Node env values are present', () => {
-    ;(import.meta as any).env = {
+    importMeta.env = {
       VITE_SUPABASE_URL: 'https://proj.supabase.co',
       VITE_SUPABASE_ANON_KEY: 'anonkey'
     }
@@ -36,7 +42,7 @@ describe('hasSupabaseConfig', () => {
   })
 
   it('returns false when env values contain placeholders', () => {
-    ;(import.meta as any).env = {
+    importMeta.env = {
       VITE_SUPABASE_URL: 'https://your-project.supabase.co',
       VITE_SUPABASE_ANON_KEY: 'your-anon-key'
     }


### PR DESCRIPTION
## Summary
- replace `as any` casts in `supabaseConfig.test.ts` with a typed interface and assertions
- run eslint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849d214568883339c51b72832ab4c23