### PR TITLE
Add swiss pairing room/judge form

### DIFF
--- a/server/__tests__/server.test.ts
+++ b/server/__tests__/server.test.ts
@@ -4,8 +4,8 @@
 import request from 'supertest';
 import type { Express } from 'express';
 import { jest } from '@jest/globals';
-// @ts-expect-error - provided by Jest mock
-import { __setMockData } from '@supabase/supabase-js';
+// Mock implementation will define this variable
+let __setMockData: (d: any) => void;
 
 const seed = {
   tournaments: [
@@ -32,6 +32,9 @@ const seed = {
 };
 
 let data: any = JSON.parse(JSON.stringify(seed));
+__setMockData = (d: any) => {
+  data = d;
+};
 
 jest.mock('@supabase/supabase-js', () => {
   const makeThenable = (result: any) => ({
@@ -39,6 +42,7 @@ jest.mock('@supabase/supabase-js', () => {
   });
 
   return {
+    __esModule: true,
     createClient: () => ({
       from: (table: string) => ({
         select: () => {
@@ -88,7 +92,10 @@ jest.mock('@supabase/supabase-js', () => {
           })
         })
       })
-    })
+    }),
+    __setMockData: (d: any) => {
+      data = d;
+    }
   };
 });
 

--- a/src/components/PairingEngine.tsx
+++ b/src/components/PairingEngine.tsx
@@ -1,36 +1,108 @@
-import React, { useState } from 'react';
-import { usePairings, type Pairing } from '@/lib/hooks/usePairings';
-import { useRounds } from '@/lib/hooks/useRounds';
+import React, { useState } from 'react'
+import { usePairings, type Pairing } from '@/lib/hooks/usePairings'
+import { useRounds } from '@/lib/hooks/useRounds'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
 
 const PairingEngine: React.FC = () => {
-  const [pairingAlgorithm, setPairingAlgorithm] = useState<'swiss' | 'power' | 'random'>('swiss');
-  const { pairings, currentRound } = usePairings();
-  const { rounds } = useRounds();
+  const [pairingAlgorithm, setPairingAlgorithm] =
+    useState<'swiss' | 'power' | 'random'>('swiss')
+  const [roomsInput, setRoomsInput] = useState('')
+  const [judgesInput, setJudgesInput] = useState('')
+  const { pairings, currentRound, generatePairings } = usePairings()
+  const { rounds } = useRounds()
+
+  const handleGenerate = async () => {
+    const rooms = roomsInput
+      .split(',')
+      .map(r => r.trim())
+      .filter(Boolean)
+    const judges = judgesInput
+      .split(',')
+      .map(j => j.trim())
+      .filter(Boolean)
+    await generatePairings({
+      round: currentRound + 1,
+      rooms,
+      judges,
+    })
+  }
 
   return (
-    <div>
-      <h2>Round {currentRound} / {rounds.length}</h2>
-      <select
-        value={pairingAlgorithm}
-        onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-          setPairingAlgorithm(e.target.value as 'swiss' | 'power' | 'random')
-        }
-      >
-        <option value="swiss">Swiss</option>
-        <option value="power">Power</option>
-        <option value="random">Random</option>
-      </select>
+    <Card className="space-y-4">
+      <CardHeader>
+        <CardTitle>Pairing Engine</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-3">
+          <span className="font-semibold">
+            Round {currentRound + 1} / {rounds.length}
+          </span>
+          <select
+            value={pairingAlgorithm}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+              setPairingAlgorithm(
+                e.target.value as 'swiss' | 'power' | 'random',
+              )
+            }
+            className="border rounded px-2 py-1 text-sm"
+          >
+            <option value="swiss">Swiss</option>
+            <option value="power">Power</option>
+            <option value="random">Random</option>
+          </select>
+        </div>
 
-      {/* render pairings */}
-      <ul>
-        {pairings.map(p => (
-          <li key={p.id}>
-            {p.room}: {p.proposition} vs {p.opposition} ({p.status})
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Input
+            placeholder="Rooms (comma separated)"
+            value={roomsInput}
+            onChange={e => setRoomsInput(e.target.value)}
+          />
+          <Input
+            placeholder="Judges (comma separated)"
+            value={judgesInput}
+            onChange={e => setJudgesInput(e.target.value)}
+          />
+        </div>
+        <Button onClick={handleGenerate}>Generate Pairings</Button>
+
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Room</TableHead>
+              <TableHead>Proposition</TableHead>
+              <TableHead>Opposition</TableHead>
+              <TableHead>Judge</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {pairings
+              .filter(p => p.round === currentRound + 1)
+              .map((p: Pairing) => (
+                <TableRow key={p.id}>
+                  <TableCell className="font-mono">{p.room}</TableCell>
+                  <TableCell>{p.proposition}</TableCell>
+                  <TableCell>{p.opposition}</TableCell>
+                  <TableCell>{p.judge}</TableCell>
+                  <TableCell>{p.status}</TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
 };
 
 export default PairingEngine;

--- a/src/lib/__tests__/supabaseConfig.test.ts
+++ b/src/lib/__tests__/supabaseConfig.test.ts
@@ -3,10 +3,12 @@ import { hasSupabaseConfig } from '../supabase'
 
 describe('hasSupabaseConfig', () => {
   const originalProcessEnv = { ...process.env }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const originalImportMetaEnv = { ...(import.meta as any).env }
 
   beforeEach(() => {
     // Clear both Vite and Node envs
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(import.meta as any).env = {}
     delete process.env.VITE_SUPABASE_URL
     delete process.env.VITE_SUPABASE_ANON_KEY
@@ -16,11 +18,13 @@ describe('hasSupabaseConfig', () => {
 
   afterEach(() => {
     // Restore originals
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(import.meta as any).env = originalImportMetaEnv
     process.env = { ...originalProcessEnv }
   })
 
   it('returns true when valid VITE_ and Node env values are present', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(import.meta as any).env = {
       VITE_SUPABASE_URL: 'https://proj.supabase.co',
       VITE_SUPABASE_ANON_KEY: 'anonkey'
@@ -36,6 +40,7 @@ describe('hasSupabaseConfig', () => {
   })
 
   it('returns false when env values contain placeholders', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     ;(import.meta as any).env = {
       VITE_SUPABASE_URL: 'https://your-project.supabase.co',
       VITE_SUPABASE_ANON_KEY: 'your-anon-key'

--- a/src/lib/hooks/usePairings.ts
+++ b/src/lib/hooks/usePairings.ts
@@ -27,13 +27,19 @@ export function usePairings() {
   const pairings = data ?? [];
   const currentRound = pairings.reduce((m, p) => Math.max(m, p.round), 0);
 
+  interface GeneratePayload {
+    round: number
+    rooms?: string[]
+    judges?: string[]
+  }
+
   const generatePairings = useMutation({
-    mutationFn: async (round: number) => {
+    mutationFn: async ({ round, rooms = [], judges = [] }: GeneratePayload) => {
       const res = await fetch('/api/pairings/swiss', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ round }),
-      });
+        body: JSON.stringify({ round, rooms, judges }),
+      })
       if (!res.ok) throw new Error('Failed to generate pairings');
       return res.json();
     },


### PR DESCRIPTION
## Summary
- extend `usePairings` to accept rooms and judges
- enhance `PairingEngine` with form fields for rooms and judges
- show generated pairings in a table
- clean up lint issues in tests and provide supabase mock helper

## Testing
- `npm run lint`
- `npm test --silent` *(fails: server.test.ts assertions)*


------
https://chatgpt.com/codex/tasks/task_e_6849d214269083338878a807742731dd