### PR TITLE
Implement tournament selection on dashboard

### DIFF
--- a/src/components/LiveAnalytics.tsx
+++ b/src/components/LiveAnalytics.tsx
@@ -7,7 +7,10 @@ import { Trophy, TrendingUp, Users, Target } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { apiFetch, expectJson } from '@/lib/api';
 
-const LiveAnalytics = () => {
+interface LiveAnalyticsProps {
+  tournamentId?: string;
+}
+const LiveAnalytics = ({ tournamentId }: LiveAnalyticsProps) => {
   const fetchStandings = async () => {
     const res = await apiFetch('/api/analytics/standings');
     if (!res.ok) throw new Error('Failed fetching standings');

--- a/src/components/PairingEngine.tsx
+++ b/src/components/PairingEngine.tsx
@@ -2,10 +2,13 @@ import React, { useState } from 'react';
 import { usePairings, type Pairing } from '@/lib/hooks/usePairings';
 import { useRounds } from '@/lib/hooks/useRounds';
 
-const PairingEngine: React.FC = () => {
+interface PairingEngineProps {
+  tournamentId?: string;
+}
+const PairingEngine: React.FC<PairingEngineProps> = ({ tournamentId }) => {
   const [pairingAlgorithm, setPairingAlgorithm] = useState<'swiss' | 'power' | 'random'>('swiss');
-  const { pairings, currentRound } = usePairings();
-  const { rounds } = useRounds();
+  const { pairings, currentRound } = usePairings(tournamentId);
+  const { rounds } = useRounds(tournamentId);
 
   return (
     <div>

--- a/src/components/ScoringInterface.tsx
+++ b/src/components/ScoringInterface.tsx
@@ -18,7 +18,11 @@ import {
 } from "@/lib/hooks/useScoring";
 
 
-const ScoringInterface = () => {
+interface ScoringInterfaceProps {
+  tournamentId?: string;
+}
+
+const ScoringInterface = ({ tournamentId }: ScoringInterfaceProps) => {
   const [selectedDebate, setSelectedDebate] = useState('');
   const [scoresData, setScoresData] = useState<SpeakerScore[]>([]);
   const [propPoints, setPropPoints] = useState(0);

--- a/src/components/__tests__/PairingEngine.test.tsx
+++ b/src/components/__tests__/PairingEngine.test.tsx
@@ -36,9 +36,9 @@ describe('PairingEngine', () => {
     });
 
     await act(async () => {
-      render(<PairingEngine />, { wrapper: createWrapper() });
+      render(<PairingEngine tournamentId="t1" />, { wrapper: createWrapper() });
     });
 
-    expect(screen.getByText(/Pairing Engine/i)).toBeInTheDocument();
+    expect(screen.getByText('Swiss')).toBeInTheDocument();
   });
 });

--- a/src/lib/__tests__/supabaseConfig.test.ts
+++ b/src/lib/__tests__/supabaseConfig.test.ts
@@ -3,11 +3,12 @@ import { hasSupabaseConfig } from '../supabase'
 
 describe('hasSupabaseConfig', () => {
   const originalProcessEnv = { ...process.env }
-  const originalImportMetaEnv = { ...(import.meta as any).env }
+  const importMeta = import.meta as unknown as { env: Record<string, string | undefined> }
+  const originalImportMetaEnv = { ...importMeta.env }
 
   beforeEach(() => {
     // Clear both Vite and Node envs
-    ;(import.meta as any).env = {}
+    importMeta.env = {}
     delete process.env.VITE_SUPABASE_URL
     delete process.env.VITE_SUPABASE_ANON_KEY
     delete process.env.SUPABASE_URL
@@ -16,12 +17,12 @@ describe('hasSupabaseConfig', () => {
 
   afterEach(() => {
     // Restore originals
-    ;(import.meta as any).env = originalImportMetaEnv
+    importMeta.env = originalImportMetaEnv
     process.env = { ...originalProcessEnv }
   })
 
   it('returns true when valid VITE_ and Node env values are present', () => {
-    ;(import.meta as any).env = {
+    importMeta.env = {
       VITE_SUPABASE_URL: 'https://proj.supabase.co',
       VITE_SUPABASE_ANON_KEY: 'anonkey'
     }
@@ -36,7 +37,7 @@ describe('hasSupabaseConfig', () => {
   })
 
   it('returns false when env values contain placeholders', () => {
-    ;(import.meta as any).env = {
+    importMeta.env = {
       VITE_SUPABASE_URL: 'https://your-project.supabase.co',
       VITE_SUPABASE_ANON_KEY: 'your-anon-key'
     }

--- a/src/lib/hooks/usePairings.ts
+++ b/src/lib/hooks/usePairings.ts
@@ -12,13 +12,15 @@ export type Pairing = {
   propWins: boolean | null;
 };
 
-export function usePairings() {
+export function usePairings(tournamentId?: string) {
   const queryClient = useQueryClient();
 
   const { data } = useQuery<Pairing[]>({
-    queryKey: ['pairings'],
+    queryKey: ['pairings', tournamentId],
     queryFn: async () => {
-      const { data, error } = await supabase.from('pairings').select('*');
+      let query = supabase.from('pairings').select('*');
+      if (tournamentId) query = query.eq('tournament_id', tournamentId);
+      const { data, error } = await query;
       if (error) throw error;
       return (data as Pairing[]) || [];
     },
@@ -37,7 +39,7 @@ export function usePairings() {
       if (!res.ok) throw new Error('Failed to generate pairings');
       return res.json();
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['pairings'] }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['pairings', tournamentId] }),
   });
 
   return { pairings, currentRound, generatePairings: generatePairings.mutateAsync };

--- a/src/lib/hooks/useRounds.ts
+++ b/src/lib/hooks/useRounds.ts
@@ -8,13 +8,15 @@ export interface Round {
   status: string;
 }
 
-export function useRounds() {
+export function useRounds(tournamentId?: string) {
   const queryClient = useQueryClient();
 
   const { data } = useQuery<Round[]>({
-    queryKey: ['rounds'],
+    queryKey: ['rounds', tournamentId],
     queryFn: async () => {
-      const { data, error } = await supabase.from('rounds').select('*');
+      let query = supabase.from('rounds').select('*');
+      if (tournamentId) query = query.eq('tournament_id', tournamentId);
+      const { data, error } = await query;
       if (error) throw error;
       return (data as Round[]) || [];
     },
@@ -30,7 +32,7 @@ export function useRounds() {
       if (error) throw error;
       return data as Round;
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds'] }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds', tournamentId] }),
   });
 
   const updateRound = useMutation({
@@ -44,7 +46,7 @@ export function useRounds() {
       if (error) throw error;
       return data as Round;
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds'] }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds', tournamentId] }),
   });
 
   const deleteRound = useMutation({
@@ -58,7 +60,7 @@ export function useRounds() {
       if (error) throw error;
       return data as Round;
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds'] }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds', tournamentId] }),
   });
 
   return {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,5 @@
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -11,22 +11,37 @@ import PairingEngine from '@/components/PairingEngine';
 import ScoringInterface from '@/components/ScoringInterface';
 import LiveAnalytics from '@/components/LiveAnalytics';
 import UserRoleManager from '@/components/UserRoleManager';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useTournaments } from '@/lib/hooks/useTournaments';
 import { Trophy, Users, Shuffle, Target, BarChart3, Settings } from 'lucide-react';
 
 const Index = () => {
   
-  const [activeTournament] = useState({
-    id: 't1',
-    name: 'Oxford Invitational 2024',
-    format: 'Swiss + Elimination',
-    rounds: 4,
-    teams: 24,
-    status: 'In Progress',
-    settings: {
-      elimination: 'single',
-      preliminaryRounds: 4
+  const { tournaments } = useTournaments();
+  const [selectedId, setSelectedId] = useState<string>('');
+
+  useEffect(() => {
+    if (!selectedId && tournaments.length > 0) {
+      setSelectedId(tournaments[0].id);
     }
-  });
+  }, [tournaments, selectedId]);
+
+  const activeTournamentData = tournaments.find(t => t.id === selectedId);
+  const activeTournament = activeTournamentData
+    ? {
+        ...activeTournamentData,
+        rounds: (activeTournamentData.settings as Record<string, unknown>)?.rounds ?? 0,
+        teams: 0,
+      }
+    : {
+        id: '',
+        name: 'No Tournament Selected',
+        format: '',
+        rounds: 0,
+        teams: 0,
+        status: '',
+        settings: {},
+      };
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -40,6 +55,16 @@ const Index = () => {
               <p className="text-slate-600 mt-1">Tournament Management System</p>
             </div>
             <div className="flex items-center gap-3">
+              <Select value={selectedId} onValueChange={setSelectedId}>
+                <SelectTrigger className="w-48">
+                  <SelectValue placeholder="Select tournament" />
+                </SelectTrigger>
+                <SelectContent>
+                  {tournaments.map(t => (
+                    <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <Badge variant={activeTournament.status === 'In Progress' ? 'default' : 'secondary'}>
                 {activeTournament.status}
               </Badge>
@@ -84,15 +109,15 @@ const Index = () => {
           </TabsContent>
 
           <TabsContent value="pairings">
-            <PairingEngine />
+            <PairingEngine tournamentId={activeTournament.id} />
           </TabsContent>
 
           <TabsContent value="scoring">
-            <ScoringInterface />
+            <ScoringInterface tournamentId={activeTournament.id} />
           </TabsContent>
 
           <TabsContent value="analytics">
-            <LiveAnalytics />
+            <LiveAnalytics tournamentId={activeTournament.id} />
           </TabsContent>
 
           <TabsContent value="admin">


### PR DESCRIPTION
## Summary
- allow choosing active tournament on dashboard
- update PairingEngine, ScoringInterface, and LiveAnalytics to accept optional tournament ID
- filter rounds and pairings by tournament
- adjust PairingEngine test
- fix linting errors

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Cannot find module '@jest/globals' in some server tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849d212dfec8333a543ff40ac8af8f4