### PR TITLE
Add tournament scoped scoring

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -675,8 +675,13 @@ app.delete('/api/rounds/:id', async (req, res) => {
 
 // ─── Debates CRUD ──────────────────────────────────────────────────────────
 
-app.get('/api/debates', async (_req, res) => {
-  const { data, error } = await supabase.from('debates').select('*')
+app.get('/api/debates', async (req, res) => {
+  const tournamentId = req.query.tournament_id as string | undefined
+  let query = supabase.from('debates').select('*')
+  if (tournamentId) {
+    query = query.eq('tournament_id', tournamentId)
+  }
+  const { data, error } = await query
   if (error) return res.status(500).json({ error: error.message })
   res.json(data)
 })
@@ -737,10 +742,15 @@ app.delete('/api/debates/:id', async (req, res) => {
 // ─── Scores CRUD ───────────────────────────────────────────────────────────
 
 app.get('/api/scores/:room', async (req, res) => {
-  const { data, error } = await supabase
+  const tournamentId = req.query.tournament_id as string | undefined
+  let query = supabase
     .from('scores')
     .select('*')
     .eq('room', req.params.room)
+  if (tournamentId) {
+    query = query.eq('tournament_id', tournamentId)
+  }
+  const { data, error } = await query
   if (error) return res.status(500).json({ error: error.message })
   res.json(data)
 })

--- a/src/components/ScoringInterface.tsx
+++ b/src/components/ScoringInterface.tsx
@@ -30,15 +30,15 @@ const ScoringInterface = ({ tournamentId }: ScoringInterfaceProps) => {
   const [oppPoints, setOppPoints] = useState(0);
   const [oppMargin, setOppMargin] = useState(0);
 
-  const { debates } = useDebates();
-  const { speakerScores } = useSpeakerScores(selectedDebate);
+  const { debates } = useDebates(tournamentId);
+  const { speakerScores } = useSpeakerScores(selectedDebate, tournamentId);
 
   useEffect(() => {
     setScoresData(speakerScores);
   }, [speakerScores]);
 
-  const { mutate: submitScores } = useSubmitSpeakerScores(selectedDebate);
-  const { mutate: submitTeamScores } = useSubmitTeamScores(selectedDebate);
+  const { mutate: submitScores } = useSubmitSpeakerScores(selectedDebate, tournamentId);
+  const { mutate: submitTeamScores } = useSubmitTeamScores(selectedDebate, tournamentId);
 
   const handleSubmit = () => {
     const valid = scoresData.every(

--- a/src/lib/__tests__/supabaseConfig.test.ts
+++ b/src/lib/__tests__/supabaseConfig.test.ts
@@ -4,8 +4,8 @@
  */
 import { hasSupabaseConfig } from '../supabase'
 
-interface MutableImportMeta extends ImportMeta {
-  env: Record<string, string | undefined>
+interface MutableImportMeta {
+  env: Record<string, any>
 }
 
 const importMeta = import.meta as unknown as MutableImportMeta


### PR DESCRIPTION
## Summary
- allow API to filter debates and scores by tournament
- thread tournamentId through scoring hooks
- pass active tournament id into scoring interface
- tweak test helper typing

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Core API Endpoints tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6849dbea7a90833383aa5a239fcfc32b