### PR TITLE
Add tournament filtering for pairings and brackets

### DIFF
--- a/server/__tests__/rounds.test.ts
+++ b/server/__tests__/rounds.test.ts
@@ -9,9 +9,9 @@ import { __setMockData } from '@supabase/supabase-js'
 
 const seed = {
   teams: [
-    { id: 1, name: 'Alpha', organization: 'Org', speakers: ['A1'] },
-    { id: 2, name: 'Bravo', organization: 'Org', speakers: ['B1'] },
-    { id: 3, name: 'Charlie', organization: 'Org', speakers: ['C1'] }
+    { id: 1, name: 'Alpha', organization: 'Org', speakers: ['A1'], tournament_id: 't1' },
+    { id: 2, name: 'Bravo', organization: 'Org', speakers: ['B1'], tournament_id: 't1' },
+    { id: 3, name: 'Charlie', organization: 'Org', speakers: ['C1'], tournament_id: 't1' }
   ],
   pairings: [],
   scores: [],
@@ -107,7 +107,7 @@ describe('Swiss pairing rounds', () => {
   it('handles odd team counts and updates current round', async () => {
     const res = await request(app)
       .post('/api/pairings/swiss')
-      .send({ round: 2 })
+      .send({ round: 2, tournament_id: 't1' })
 
     expect(res.status).toBe(201)
     expect(Array.isArray(res.body)).toBe(true)
@@ -129,7 +129,8 @@ describe('Round progression', () => {
         opposition: 'Bravo',
         judge: 'J1',
         status: 'scheduled',
-        propWins: null
+        propWins: null,
+        tournament_id: 't1'
       }
     ]
 
@@ -149,7 +150,8 @@ describe('Round progression', () => {
         opposition: 'Bravo',
         judge: 'J1',
         status: 'completed',
-        propWins: true
+        propWins: true,
+        tournament_id: 't1'
       }
     ]
 

--- a/server/__tests__/server.test.ts
+++ b/server/__tests__/server.test.ts
@@ -18,7 +18,7 @@ const seed = {
     { id: 's1', team_id: 1, name: 'A1', position: 1 }
   ],
   pairings: [
-    { id: 1, round: 1, room: 'A1', proposition: 'Alpha', opposition: 'Beta', judge: 'Judge', status: 'scheduled', propWins: null }
+    { id: 1, round: 1, room: 'A1', proposition: 'Alpha', opposition: 'Beta', judge: 'Judge', status: 'scheduled', propWins: null, tournament_id: 't1' }
   ],
   scores: [
     { id: 1, room: 'A1', speaker: 'A1', team: 'Alpha', total: 75 }
@@ -155,7 +155,9 @@ describe('Core API Endpoints', () => {
   });
 
   it('POST /api/bracket should generate a bracket', async () => {
-    const res = await request(app).post('/api/bracket').send({ type: 'single' });
+    const res = await request(app)
+      .post('/api/bracket')
+      .send({ type: 'single', tournament_id: 't1' });
     expect(res.status).toBe(201);
     expect(res.body).toHaveProperty('id');
   });

--- a/server/pairing/swiss.ts
+++ b/server/pairing/swiss.ts
@@ -22,6 +22,7 @@ export async function generateSwissPairings(
   constraints: Constraint[] = [],
   rooms: string[] = [],
   judges: string[] = [],
+  tournamentId?: string,
 ): Promise<Pairing[]> {
   const settings = await loadConstraintSettings();
   const active = constraints.filter(c => settings[c.type as keyof typeof settings]);
@@ -46,6 +47,7 @@ export async function generateSwissPairings(
       judge: judges[i / 2] || 'TBD',
       status: 'scheduled',
       propWins: null,
+      tournament_id: tournamentId,
     });
   }
   const context: ConstraintContext = { previousPairings, roomList: rooms };

--- a/server/server.ts
+++ b/server/server.ts
@@ -57,6 +57,7 @@ const roundSchema = z.object({
 })
 
 const pairingSchema = z.object({
+  tournament_id: z.string(),
   round: z.number(),
   room: z.string(),
   proposition: z.string(),
@@ -103,6 +104,7 @@ const tournamentSchema = z.object({
 
 const bracketSchema = z.object({
   type: z.enum(['single', 'double']),
+  tournament_id: z.string(),
 })
 
 // ─── Middleware to check Supabase configuration ────────────────────────────
@@ -453,8 +455,11 @@ app.get('/api/tournament/stats', async (_req, res) => {
 
 // ─── Pairings CRUD ─────────────────────────────────────────────────────────
 
-app.get('/api/pairings', async (_req, res) => {
-  const { data: pairings, error: pErr } = await supabase.from('pairings').select('*')
+app.get('/api/pairings', async (req, res) => {
+  const tournamentId = req.query.tournament_id as string | undefined
+  let pairingQuery = supabase.from('pairings').select('*')
+  if (tournamentId) pairingQuery = pairingQuery.eq('tournament_id', tournamentId)
+  const { data: pairings, error: pErr } = await pairingQuery
   const { data: setting, error: sErr } = await supabase.from('settings').select('currentRound').single()
   if (pErr || sErr) {
     const msg = pErr?.message || sErr?.message
@@ -496,14 +501,17 @@ app.post('/api/bracket', async (req, res) => {
     return res.status(400).json({ error: 'Invalid request body' })
   }
 
-  const { data: teams, error: tErr } = await supabase.from('teams').select('*')
+  const { data: teams, error: tErr } = await supabase
+    .from('teams')
+    .select('*')
+    .eq('tournament_id', parsed.data.tournament_id)
   if (tErr) return res.status(500).json({ error: tErr.message })
 
   const bracket = generateEliminationBracket((teams as any[]) || [], parsed.data.type)
 
   const { data, error } = await supabase
     .from('brackets')
-    .insert({ type: parsed.data.type, data: bracket })
+    .insert({ type: parsed.data.type, tournament_id: parsed.data.tournament_id, data: bracket })
     .select()
     .single()
   if (error) return res.status(400).json({ error: error.message })
@@ -525,8 +533,15 @@ app.put('/api/pairings/:id', async (req, res) => {
   if (error) return res.status(404).json({ error: error.message })
 
   if (Object.prototype.hasOwnProperty.call(parsed.data, 'propWins')) {
-    const { data: bracketRec } = await supabase.from('brackets').select('*').single()
-    const { data: allPairings } = await supabase.from('pairings').select('*')
+    const { data: bracketRec } = await supabase
+      .from('brackets')
+      .select('*')
+      .eq('tournament_id', data.tournament_id)
+      .single()
+    const { data: allPairings } = await supabase
+      .from('pairings')
+      .select('*')
+      .eq('tournament_id', data.tournament_id)
     if (bracketRec && allPairings) {
       const updated = updateBracketWithResults(bracketRec.data, allPairings as any[])
       await supabase.from('brackets').update({ data: updated }).eq('id', bracketRec.id)
@@ -553,17 +568,36 @@ app.post('/api/pairings/swiss', async (req, res) => {
   const round = req.body?.round
   const rooms = Array.isArray(req.body?.rooms) ? req.body.rooms : []
   const judges = Array.isArray(req.body?.judges) ? req.body.judges : []
+  const tournamentId = req.body?.tournament_id
   if (typeof round !== 'number') {
     return res.status(400).json({ error: 'round is required' })
   }
 
-  const { data: teams, error: tErr } = await supabase.from('teams').select('*')
+  if (!tournamentId) {
+    return res.status(400).json({ error: 'tournament_id is required' })
+  }
+
+  const { data: teams, error: tErr } = await supabase
+    .from('teams')
+    .select('*')
+    .eq('tournament_id', tournamentId)
   if (tErr) return res.status(500).json({ error: tErr.message })
 
-  const { data: prev, error: hErr } = await supabase.from('pairings').select('*')
+  const { data: prev, error: hErr } = await supabase
+    .from('pairings')
+    .select('*')
+    .eq('tournament_id', tournamentId)
   if (hErr) return res.status(500).json({ error: hErr.message })
 
-  const pairings = await generateSwissPairings(round, teams || [], prev || [], [], rooms, judges)
+  const pairings = await generateSwissPairings(
+    round,
+    teams || [],
+    prev || [],
+    [],
+    rooms,
+    judges,
+    tournamentId
+  )
 
   const { data: inserted, error: pErr } = await supabase
     .from('pairings')

--- a/src/lib/hooks/useBracket.ts
+++ b/src/lib/hooks/useBracket.ts
@@ -26,6 +26,7 @@ export interface Bracket {
  */
 export interface BracketRecord {
   id: string
+  tournament_id: string
   type: 'single' | 'double'
   data: Bracket
 }
@@ -34,14 +35,13 @@ export interface BracketRecord {
  * Hook to fetch the current bracket from Supabase.
  * Returns `{ bracket: BracketRecord | null }`.
  */
-export function useBracket() {
+export function useBracket(tournamentId?: string) {
   const { data } = useQuery<BracketRecord | null>({
-    queryKey: ['bracket'],
+    queryKey: ['bracket', tournamentId],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('brackets')
-        .select('*')
-        .single()
+      let query = supabase.from('brackets').select('*')
+      if (tournamentId) query = query.eq('tournament_id', tournamentId)
+      const { data, error } = await query.single()
 
       if (error) {
         // Supabase returns PGRST116 when no record exists

--- a/src/lib/hooks/usePairings.ts
+++ b/src/lib/hooks/usePairings.ts
@@ -3,6 +3,7 @@ import { supabase } from '../supabase';
 
 export type Pairing = {
   id: number;
+  tournament_id: string;
   round: number;
   room: string;
   proposition: string;
@@ -40,7 +41,7 @@ export function usePairings(tournamentId?: string) {
       const res = await fetch('/api/pairings/swiss', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ round, rooms, judges }),
+        body: JSON.stringify({ round, rooms, judges, tournament_id: tournamentId }),
       })
       if (!res.ok) throw new Error('Failed to generate pairings');
       return res.json();

--- a/src/lib/pairing/constraints.ts
+++ b/src/lib/pairing/constraints.ts
@@ -1,4 +1,5 @@
 export type Pairing = {
+  tournament_id?: string
   round: number;
   room: string;
   proposition: string;

--- a/supabase/migrations/0004_add_tournament_id_to_pairings_brackets.sql
+++ b/supabase/migrations/0004_add_tournament_id_to_pairings_brackets.sql
@@ -1,0 +1,8 @@
+-- 0004_add_tournament_id_to_pairings_brackets.sql
+-- Add tournament_id column to pairings and brackets tables
+
+ALTER TABLE public.pairings
+  ADD COLUMN tournament_id uuid REFERENCES public.tournaments(id) ON DELETE CASCADE;
+
+ALTER TABLE public.brackets
+  ADD COLUMN tournament_id uuid REFERENCES public.tournaments(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Summary
- allow pairings and brackets to reference tournaments
- include tournament_id when generating Swiss pairings or brackets
- update frontend hooks for pairings and brackets
- adjust tests for new tournament_id field
- add migration for tournament_id columns

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6849dbe9e4ec8333a9be04d567c79986