### PR TITLE
Handle tournament ID in team utilities

### DIFF
--- a/src/components/TeamRoster.tsx
+++ b/src/components/TeamRoster.tsx
@@ -15,6 +15,7 @@ type Team = {
   id: number;
   name: string;
   organization: string;
+  tournament_id: string;
   speakers: string[];
   wins: number;
   losses: number;
@@ -57,7 +58,13 @@ const TeamRoster = ({ tournamentId }: TeamRosterProps) => {
     if (validSpeakers.length > 5) {
       throw new Error('Cannot add more than 5 speakers');
     }
-    await addTeam({ name: teamName, organization, speakers: validSpeakers });
+    if (!tournamentId) throw new Error('No active tournament');
+    await addTeam({
+      name: teamName,
+      organization,
+      speakers: validSpeakers,
+      tournament_id: tournamentId,
+    });
   };
 
   const editTeam = async (payload: { id: number; updates: Partial<Team> }) => {
@@ -89,8 +96,9 @@ const TeamRoster = ({ tournamentId }: TeamRosterProps) => {
     if (!file) return;
     const text = await file.text();
     const parsed = parseTeamsCsv(text);
+    if (!tournamentId) throw new Error('No active tournament');
     for (const team of parsed) {
-      await addTeam(team);
+      await addTeam({ ...team, tournament_id: tournamentId });
     }
     if (fileInputRef.current) fileInputRef.current.value = '';
   };

--- a/src/lib/__tests__/supabaseConfig.test.ts
+++ b/src/lib/__tests__/supabaseConfig.test.ts
@@ -5,7 +5,7 @@
 import { hasSupabaseConfig } from '../supabase'
 
 interface MutableImportMeta extends ImportMeta {
-  env: Record<string, string | undefined>
+  env: ImportMetaEnv & Record<string, string | undefined>
 }
 
 const importMeta = import.meta as unknown as MutableImportMeta
@@ -16,7 +16,7 @@ describe('hasSupabaseConfig', () => {
 
   beforeEach(() => {
     // Clear both Vite and Node envs
-    importMeta.env = {}
+    importMeta.env = {} as any
     delete process.env.VITE_SUPABASE_URL
     delete process.env.VITE_SUPABASE_ANON_KEY
     delete process.env.SUPABASE_URL
@@ -25,7 +25,7 @@ describe('hasSupabaseConfig', () => {
 
   afterEach(() => {
     // Restore originals
-    importMeta.env = originalImportMetaEnv
+    importMeta.env = originalImportMetaEnv as any
     process.env = { ...originalProcessEnv }
   })
 
@@ -33,7 +33,7 @@ describe('hasSupabaseConfig', () => {
     importMeta.env = {
       VITE_SUPABASE_URL: 'https://proj.supabase.co',
       VITE_SUPABASE_ANON_KEY: 'anonkey'
-    }
+    } as any
     process.env.SUPABASE_URL = 'https://proj.supabase.co'
     process.env.SUPABASE_ANON_KEY = 'anonkey'
 
@@ -48,7 +48,7 @@ describe('hasSupabaseConfig', () => {
     importMeta.env = {
       VITE_SUPABASE_URL: 'https://your-project.supabase.co',
       VITE_SUPABASE_ANON_KEY: 'your-anon-key'
-    }
+    } as any
     process.env.SUPABASE_URL = 'https://your-project.supabase.co'
     process.env.SUPABASE_ANON_KEY = 'your-anon-key'
 

--- a/src/lib/hooks/useTeams.ts
+++ b/src/lib/hooks/useTeams.ts
@@ -6,6 +6,7 @@ export type Team = {
   id: number;
   name: string;
   organization: string;
+  tournament_id: string;
   speakers: string[];
   wins: number;
   losses: number;
@@ -26,10 +27,12 @@ export function useTeams(tournamentId?: string) {
   });
 
   const addTeam = useMutation({
-    mutationFn: async (team: Omit<Team, 'id' | 'wins' | 'losses' | 'speakerPoints'>) => {
+    mutationFn: async (
+      team: Omit<Team, 'id' | 'wins' | 'losses' | 'speakerPoints' | 'tournament_id'>,
+    ) => {
       const { data, error } = await supabase
         .from('teams')
-        .insert(team)
+        .insert({ ...team, tournament_id: tournamentId })
         .select()
         .single();
       if (error) throw error;


### PR DESCRIPTION
## Summary
- include `tournament_id` on teams
- pass `tournament_id` when creating teams
- include active tournament ID when importing CSV
- adjust Supabase config test for newer ImportMeta typing

## Testing
- `npm run lint`
- `npm test --silent` *(fails: several server tests do not pass)*

------
https://chatgpt.com/codex/tasks/task_e_6849dbe9744483338715d1fcdcfb2881