### PR TITLE
Add tournament_id to team CSV format

### DIFF
--- a/__mocks__/supabase-js.js
+++ b/__mocks__/supabase-js.js
@@ -46,9 +46,11 @@ export const createClient = () => ({
     },
     update: values => ({
       eq: (field, value) => {
-        const idx = (mockData[table] || []).findIndex(r => r[field] === value);
-        if (idx !== -1) mockData[table][idx] = { ...mockData[table][idx], ...values };
-        const updated = { data: mockData[table][idx] || null, error: null };
+        const list = mockData[table] || [];
+        const idx = list.findIndex(r => r[field] === value);
+        if (idx !== -1) list[idx] = { ...list[idx], ...values };
+        mockData[table] = list;
+        const updated = { data: list[idx] || null, error: null };
         const promise = makeThenable(updated);
         promise.select = () => ({ single: () => Promise.resolve(updated) });
         return promise;

--- a/src/components/TeamRoster.tsx
+++ b/src/components/TeamRoster.tsx
@@ -57,7 +57,12 @@ const TeamRoster = ({ tournamentId }: TeamRosterProps) => {
     if (validSpeakers.length > 5) {
       throw new Error('Cannot add more than 5 speakers');
     }
-    await addTeam({ name: teamName, organization, speakers: validSpeakers });
+    await addTeam({
+      tournament_id: tournamentId ?? '',
+      name: teamName,
+      organization,
+      speakers: validSpeakers,
+    });
   };
 
   const editTeam = async (payload: { id: number; updates: Partial<Team> }) => {
@@ -70,6 +75,7 @@ const TeamRoster = ({ tournamentId }: TeamRosterProps) => {
 
   const handleExport = () => {
     const data: TeamCsv[] = teams.map(t => ({
+      tournament_id: tournamentId ?? '',
       name: t.name,
       organization: t.organization,
       speakers: t.speakers,
@@ -90,7 +96,7 @@ const TeamRoster = ({ tournamentId }: TeamRosterProps) => {
     const text = await file.text();
     const parsed = parseTeamsCsv(text);
     for (const team of parsed) {
-      await addTeam(team);
+      await addTeam({ ...team, tournament_id: tournamentId ?? team.tournament_id });
     }
     if (fileInputRef.current) fileInputRef.current.value = '';
   };

--- a/src/lib/__tests__/csv.test.ts
+++ b/src/lib/__tests__/csv.test.ts
@@ -2,10 +2,11 @@ import { parseTeamsCsv, teamsToCsv, TeamCsv } from '../csv';
 
 describe('CSV utils', () => {
   const teams: TeamCsv[] = [
-    { name: 'Alpha', organization: 'Org A', speakers: ['A1', 'A2'] },
-    { name: 'Beta', organization: 'Org B', speakers: ['B1', 'B2', 'B3'] },
-    { name: 'Gamma', organization: 'Org C', speakers: ['C1', 'C2', 'C3', 'C4'] },
+    { tournament_id: 't1', name: 'Alpha', organization: 'Org A', speakers: ['A1', 'A2'] },
+    { tournament_id: 't1', name: 'Beta', organization: 'Org B', speakers: ['B1', 'B2', 'B3'] },
+    { tournament_id: 't1', name: 'Gamma', organization: 'Org C', speakers: ['C1', 'C2', 'C3', 'C4'] },
     {
+      tournament_id: 't1',
       name: 'Delta',
       organization: 'Org D',
       speakers: ['D1', 'D2', 'D3', 'D4', 'D5'],
@@ -20,16 +21,18 @@ describe('CSV utils', () => {
 
   it('parses CSV string with varying speaker counts', () => {
     const csv =
-      'Team Name,Organization,Speaker 1,Speaker 2,Speaker 3,Speaker 4,Speaker 5\n' +
-      'Omega,Org X,X1,X2,X3,X4,X5\n' +
-      'Sigma,Org Y,Y1,Y2,Y3,Y4,';
+      'Tournament ID,Team Name,Organization,Speaker 1,Speaker 2,Speaker 3,Speaker 4,Speaker 5\n' +
+      't1,Omega,Org X,X1,X2,X3,X4,X5\n' +
+      't1,Sigma,Org Y,Y1,Y2,Y3,Y4,';
     expect(parseTeamsCsv(csv)).toEqual([
       {
+        tournament_id: 't1',
         name: 'Omega',
         organization: 'Org X',
         speakers: ['X1', 'X2', 'X3', 'X4', 'X5'],
       },
       {
+        tournament_id: 't1',
         name: 'Sigma',
         organization: 'Org Y',
         speakers: ['Y1', 'Y2', 'Y3', 'Y4'],

--- a/src/lib/__tests__/supabaseConfig.test.ts
+++ b/src/lib/__tests__/supabaseConfig.test.ts
@@ -4,7 +4,7 @@
  */
 import { hasSupabaseConfig } from '../supabase'
 
-interface MutableImportMeta extends ImportMeta {
+interface MutableImportMeta extends Omit<ImportMeta, 'env'> {
   env: Record<string, string | undefined>
 }
 

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,4 +1,5 @@
 export type TeamCsv = {
+  tournament_id: string;
   name: string;
   organization: string;
   speakers: string[];
@@ -6,10 +7,19 @@ export type TeamCsv = {
 
 export function teamsToCsv(teams: TeamCsv[]): string {
   const header =
-    'Team Name,Organization,Speaker 1,Speaker 2,Speaker 3,Speaker 4,Speaker 5';
+    'Tournament ID,Team Name,Organization,Speaker 1,Speaker 2,Speaker 3,Speaker 4,Speaker 5';
   const rows = teams.map(team => {
     const [s1 = '', s2 = '', s3 = '', s4 = '', s5 = ''] = team.speakers;
-    const values = [team.name, team.organization, s1, s2, s3, s4, s5];
+    const values = [
+      team.tournament_id,
+      team.name,
+      team.organization,
+      s1,
+      s2,
+      s3,
+      s4,
+      s5,
+    ];
     return values.map(v => `"${(v ?? '').replace(/"/g, '""')}"`).join(',');
   });
   return [header, ...rows].join('\n');
@@ -21,6 +31,7 @@ export function parseTeamsCsv(csv: string): TeamCsv[] {
   lines.shift();
   return lines.map(line => {
     const [
+      tournament_id = '',
       name = '',
       organization = '',
       sp1 = '',
@@ -31,6 +42,11 @@ export function parseTeamsCsv(csv: string): TeamCsv[] {
     ] = line.split(',');
     const clean = (v: string) => v.trim().replace(/^"|"$/g, '');
     const speakers = [sp1, sp2, sp3, sp4, sp5].map(clean).filter(Boolean);
-    return { name: clean(name), organization: clean(organization), speakers };
+    return {
+      tournament_id: clean(tournament_id),
+      name: clean(name),
+      organization: clean(organization),
+      speakers,
+    };
   });
 }


### PR DESCRIPTION
## Summary
- include `tournament_id` column in `teamsToCsv` and `parseTeamsCsv`
- adjust CSV tests for new column
- include tournament id when exporting or importing teams in TeamRoster
- fix supabase config test type
- guard mocked supabase update against missing tables

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Core API server tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849dbea768883338279d90c1e0fd8aa