### PR TITLE
Integrate auth pages with Supabase users table

### DIFF
--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -38,8 +38,14 @@ export default function SignIn() {
     if (userId) {
       await supabase
         .from('users')
-        .update({ last_login: new Date().toISOString() })
-        .eq('id', userId)
+        .upsert({
+          id: userId,
+          email,
+          name: data.user.user_metadata?.name ?? null,
+          role: 'user',
+          is_active: true,
+          last_login: new Date().toISOString(),
+        })
     }
     navigate('/')
   }

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -30,7 +30,11 @@ export default function SignUp() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const { data, error } = await supabase.auth.signUp({ email, password })
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { name } }
+    })
     if (error) {
       setError(error.message)
     } else {
@@ -38,7 +42,14 @@ export default function SignUp() {
       if (userId) {
         await supabase
           .from('users')
-          .upsert({ id: userId, email, name, role: 'user' })
+          .upsert({
+            id: userId,
+            email,
+            name,
+            role: 'user',
+            is_active: true,
+            last_login: null,
+          })
       }
       navigate('/')
     }

--- a/supabase/migrations/0007_users_add_columns.sql
+++ b/supabase/migrations/0007_users_add_columns.sql
@@ -1,0 +1,5 @@
+-- Add additional fields to users table
+ALTER TABLE public.users
+  ADD COLUMN avatar_url text,
+  ADD COLUMN is_active boolean NOT NULL DEFAULT true,
+  ADD COLUMN last_login timestamptz;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,8 +1,16 @@
 -- Seed data for DebateMinistrator
 -- Inserts an admin user placeholder
 
-INSERT INTO public.users (id, email, role, name)
-VALUES ('00000000-0000-0000-0000-000000000001', 'admin@luis.martin', 'admin', 'Admin User')
+INSERT INTO public.users (id, email, role, name, is_active, avatar_url, last_login)
+VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  'admin@luis.martin',
+  'admin',
+  'Admin User',
+  true,
+  NULL,
+  NULL
+)
 ON CONFLICT DO NOTHING;
 
 -- Initialize settings with round 1


### PR DESCRIPTION
## Summary
- track user last login and metadata on sign-in
- record profile info when signing up
- extend Supabase schema with new user columns
- update seed data for new fields

## Testing
- `npm run lint`
- `npm test --silent` *(fails: unused `@ts-expect-error` directive, usersRouter auth test 401, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6849ebb0881c8333a0041045626135f4