### PR TITLE
Fix dev server port

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig(({ mode }) => {
   return {
     server: {
       host: '::',
-      port: 8080,
+      // Use Vite's default port to align with documentation
+      port: 5173,
     },
     plugins: [react(), mode === 'development' && componentTagger()].filter(Boolean),
     resolve: {


### PR DESCRIPTION
## Summary
- set Vite dev server back to the default 5173 port so it matches the docs

## Testing
- `npm run lint`
- `npm test --silent` *(fails: Core API and hooks test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68696b09fdd88333b37a0b424561d408