### PR TITLE
Update README environment notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ DebateMinistrator is a modern, web-based platform designed to streamline the end
    cp .env.example .env
    ```
 
+   After copying, **edit `.env` and fill in `SUPABASE_URL`, `SUPABASE_ANON_KEY`,
+   `VITE_SUPABASE_URL`, and `VITE_SUPABASE_ANON_KEY`**. These correspond to lines
+   5–8 in `.env.example`. The server refuses to start if any of them are missing.
+
 2. Edit `.env` to configure the backend endpoint and Supabase credentials. `VITE_API_BASE_URL` controls the API server URL and defaults to `http://localhost:3001`.
 
    Create a project at [Supabase](https://supabase.com), then copy the **Project URL** and **Anon public key** from the dashboard. Add them to `.env`:
@@ -170,7 +174,7 @@ DebateMinistrator is a modern, web-based platform designed to streamline the end
 1. Sign in to [Supabase](https://supabase.com) and create a new project.
 2. In your project's **Settings → API** section copy the **Project URL** and **Anon public key**.
 3. Paste those values into the corresponding variables in your `.env` file as shown above.
-4. These variables must be present when starting the API server or building the frontend. The server reads `SUPABASE_URL` and `SUPABASE_ANON_KEY` exclusively – they will **not** be injected into the browser unless the same values are duplicated using the `VITE_` prefix.
+4. These variables must be present when starting the API server or building the frontend. The server reads `SUPABASE_URL` and `SUPABASE_ANON_KEY` exclusively – they will **not** be injected into the browser unless the same values are duplicated using the `VITE_` prefix. Missing any of them (see `.env.example` lines 5–8) causes `npm run server` to fail.
 5. See [docs/credentials.md](docs/credentials.md) for the default admin login and a list of required environment variables. These must be configured before running `npm run create-admin`.
 6. The login and signup pages require `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to be set in `.env`. If either variable is missing or contains placeholder text, the app displays a “Setup Required” screen (the `AuthFallback` component) instead of the forms.
 7. When deploying to platforms like **Vercel** or **Netlify**, add these environment variables in the platform dashboard and redeploy the application so the build picks them up.


### PR DESCRIPTION
## Summary
- document copying `.env.example`
- warn about missing Supabase credentials and Vite equivalents

## Testing
- `npm run lint`
- `npm test --silent` *(fails: usersRoutes, server.test, and useUserProfile.test)*

------
https://chatgpt.com/codex/tasks/task_e_68696ee578408333b5cf722e5d362742