### PR TITLE
refactor: use localStorage in hooks

### DIFF
--- a/src/lib/hooks/usePairings.ts
+++ b/src/lib/hooks/usePairings.ts
@@ -1,5 +1,18 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '../supabase';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+
+function readLocal<T>(key: string): T[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    return JSON.parse(localStorage.getItem(key) || '[]') as T[]
+  } catch {
+    return []
+  }
+}
+
+function writeLocal<T>(key: string, value: T[]): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(key, JSON.stringify(value))
+}
 
 export type Pairing = {
   id: number;
@@ -18,14 +31,11 @@ export function usePairings(tournamentId?: string) {
 
   const { data } = useQuery<Pairing[]>({
     queryKey: ['pairings', tournamentId],
-    queryFn: async () => {
-      let query = supabase.from('pairings').select('*');
-      if (tournamentId) query = query.eq('tournament_id', tournamentId);
-      const { data, error } = await query;
-      if (error) throw error;
-      return (data as Pairing[]) || [];
+    queryFn: () => {
+      const data = readLocal<Pairing>('pairings')
+      return tournamentId ? data.filter((p) => p.tournament_id === tournamentId) : data
     },
-  });
+  })
 
   const pairings = data ?? [];
   const currentRound = pairings.reduce((m, p) => Math.max(m, p.round), 0);
@@ -44,7 +54,10 @@ export function usePairings(tournamentId?: string) {
         body: JSON.stringify({ round, rooms, judges, tournament_id: tournamentId }),
       })
       if (!res.ok) throw new Error('Failed to generate pairings');
-      return res.json();
+      const generated = (await res.json()) as Pairing[]
+      const existing = readLocal<Pairing>('pairings')
+      writeLocal('pairings', [...existing, ...generated])
+      return generated
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['pairings', tournamentId] }),
   });

--- a/src/lib/hooks/useRounds.ts
+++ b/src/lib/hooks/useRounds.ts
@@ -1,5 +1,18 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '../supabase';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+
+function readLocal<T>(key: string): T[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    return JSON.parse(localStorage.getItem(key) || '[]') as T[]
+  } catch {
+    return []
+  }
+}
+
+function writeLocal<T>(key: string, value: T[]): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(key, JSON.stringify(value))
+}
 
 export interface Round {
   id: string;
@@ -13,52 +26,42 @@ export function useRounds(tournamentId?: string) {
 
   const { data } = useQuery<Round[]>({
     queryKey: ['rounds', tournamentId],
-    queryFn: async () => {
-      let query = supabase.from('rounds').select('*');
-      if (tournamentId) query = query.eq('tournament_id', tournamentId);
-      const { data, error } = await query;
-      if (error) throw error;
-      return (data as Round[]) || [];
+    queryFn: () => {
+      const data = readLocal<Round>('rounds')
+      return tournamentId ? data.filter((r) => r.tournament_id === tournamentId) : data
     },
-  });
+  })
 
   const addRound = useMutation({
     mutationFn: async (round: Omit<Round, 'id'>) => {
-      const { data, error } = await supabase
-        .from('rounds')
-        .insert(round)
-        .select()
-        .single();
-      if (error) throw error;
-      return data as Round;
+      const rounds = readLocal<Round>('rounds')
+      const newRound: Round = { id: Date.now().toString(), ...round }
+      writeLocal('rounds', [...rounds, newRound])
+      return newRound
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds', tournamentId] }),
   });
 
   const updateRound = useMutation({
     mutationFn: async ({ id, updates }: { id: string; updates: Partial<Round> }) => {
-      const { data, error } = await supabase
-        .from('rounds')
-        .update(updates)
-        .eq('id', id)
-        .select()
-        .single();
-      if (error) throw error;
-      return data as Round;
+      const rounds = readLocal<Round>('rounds')
+      const idx = rounds.findIndex((r) => r.id === id)
+      if (idx === -1) throw new Error('Round not found')
+      rounds[idx] = { ...rounds[idx], ...updates }
+      writeLocal('rounds', rounds)
+      return rounds[idx]
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds', tournamentId] }),
   });
 
   const deleteRound = useMutation({
     mutationFn: async (id: string) => {
-      const { data, error } = await supabase
-        .from('rounds')
-        .delete()
-        .eq('id', id)
-        .select()
-        .single();
-      if (error) throw error;
-      return data as Round;
+      const rounds = readLocal<Round>('rounds')
+      const idx = rounds.findIndex((r) => r.id === id)
+      if (idx === -1) throw new Error('Round not found')
+      const [removed] = rounds.splice(idx, 1)
+      writeLocal('rounds', rounds)
+      return removed
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['rounds', tournamentId] }),
   });

--- a/src/lib/hooks/useSpeakers.ts
+++ b/src/lib/hooks/useSpeakers.ts
@@ -1,6 +1,18 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '../supabase';
-import { apiFetch, expectJson } from '../api';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+
+function readLocal<T>(key: string): T[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    return JSON.parse(localStorage.getItem(key) || '[]') as T[]
+  } catch {
+    return []
+  }
+}
+
+function writeLocal<T>(key: string, value: T[]): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(key, JSON.stringify(value))
+}
 
 export interface Speaker {
   id: string;
@@ -14,54 +26,45 @@ export function useSpeakers(teamId?: string, tournamentId?: string) {
 
   const { data } = useQuery<Speaker[]>({
     queryKey: ['speakers', teamId, tournamentId],
-    queryFn: async () => {
-      const params = new URLSearchParams();
-      if (teamId) params.set('team_id', teamId);
-      if (!teamId && tournamentId) params.set('tournament_id', tournamentId);
-      const qs = params.toString();
-      const res = await apiFetch(`/api/speakers${qs ? `?${qs}` : ''}`);
-      if (!res.ok) throw new Error('Failed fetching speakers');
-      return expectJson<Speaker[]>(res);
+    queryFn: () => {
+      const data = readLocal<Speaker>('speakers')
+      let result = data
+      if (teamId) result = result.filter((s) => s.team_id === teamId)
+      else if (tournamentId) result = result.filter((s) => s.team_id.startsWith(tournamentId))
+      return result
     },
-  });
+  })
 
   const addSpeaker = useMutation({
     mutationFn: async (speaker: Omit<Speaker, 'id'>) => {
-      const { data, error } = await supabase
-        .from('speakers')
-        .insert(speaker)
-        .select()
-        .single();
-      if (error) throw error;
-      return data as Speaker;
+      const speakers = readLocal<Speaker>('speakers')
+      const newSpeaker: Speaker = { id: Date.now().toString(), ...speaker }
+      writeLocal('speakers', [...speakers, newSpeaker])
+      return newSpeaker
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['speakers'] }),
   });
 
   const updateSpeaker = useMutation({
     mutationFn: async ({ id, updates }: { id: string; updates: Partial<Speaker> }) => {
-      const { data, error } = await supabase
-        .from('speakers')
-        .update(updates)
-        .eq('id', id)
-        .select()
-        .single();
-      if (error) throw error;
-      return data as Speaker;
+      const speakers = readLocal<Speaker>('speakers')
+      const idx = speakers.findIndex((s) => s.id === id)
+      if (idx === -1) throw new Error('Speaker not found')
+      speakers[idx] = { ...speakers[idx], ...updates }
+      writeLocal('speakers', speakers)
+      return speakers[idx]
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['speakers'] }),
   });
 
   const deleteSpeaker = useMutation({
     mutationFn: async (id: string) => {
-      const { data, error } = await supabase
-        .from('speakers')
-        .delete()
-        .eq('id', id)
-        .select()
-        .single();
-      if (error) throw error;
-      return data as Speaker;
+      const speakers = readLocal<Speaker>('speakers')
+      const idx = speakers.findIndex((s) => s.id === id)
+      if (idx === -1) throw new Error('Speaker not found')
+      const [removed] = speakers.splice(idx, 1)
+      writeLocal('speakers', speakers)
+      return removed
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['speakers'] }),
   });

--- a/src/lib/hooks/useTeams.ts
+++ b/src/lib/hooks/useTeams.ts
@@ -1,6 +1,18 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '../supabase';
-import { apiFetch, expectJson } from '../api';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+
+function readLocal<T>(key: string): T[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    return JSON.parse(localStorage.getItem(key) || '[]') as T[]
+  } catch {
+    return []
+  }
+}
+
+function writeLocal<T>(key: string, value: T[]): void {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(key, JSON.stringify(value))
+}
 
 export type Team = {
   id: number;
@@ -18,53 +30,53 @@ export function useTeams(tournamentId?: string) {
 
   const { data: teams } = useQuery<Team[]>({
     queryKey: ['teams', tournamentId],
-    queryFn: async () => {
-      const qs = tournamentId ? `?tournament_id=${encodeURIComponent(tournamentId)}` : '';
-      const res = await apiFetch(`/api/teams${qs}`);
-      if (!res.ok) throw new Error('Failed fetching teams');
-      return expectJson<Team[]>(res);
+    queryFn: () => {
+      const data = readLocal<Team>('teams')
+      return tournamentId
+        ? data.filter((t) => t.tournament_id === tournamentId)
+        : data
     },
-  });
+  })
 
   const addTeam = useMutation({
     mutationFn: async (
       team: Omit<Team, 'id' | 'wins' | 'losses' | 'speakerPoints' | 'tournament_id'>,
     ) => {
-      const { data, error } = await supabase
-        .from('teams')
-        .insert({ ...team, tournament_id: tournamentId })
-        .select()
-        .single();
-      if (error) throw error;
-      return data as Team;
+      const existing = readLocal<Team>('teams')
+      const newTeam: Team = {
+        id: Date.now(),
+        wins: 0,
+        losses: 0,
+        speakerPoints: 0,
+        tournament_id: tournamentId || '',
+        ...team,
+      }
+      writeLocal('teams', [...existing, newTeam])
+      return newTeam
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['teams'] }),
   });
 
   const updateTeam = useMutation({
     mutationFn: async ({ id, updates }: { id: number; updates: Partial<Team> }) => {
-      const { data, error } = await supabase
-        .from('teams')
-        .update(updates)
-        .eq('id', id)
-        .select()
-        .single();
-      if (error) throw error;
-      return data as Team;
+      const teams = readLocal<Team>('teams')
+      const idx = teams.findIndex((t) => t.id === id)
+      if (idx === -1) throw new Error('Team not found')
+      teams[idx] = { ...teams[idx], ...updates }
+      writeLocal('teams', teams)
+      return teams[idx]
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['teams'] }),
   });
 
   const deleteTeam = useMutation({
     mutationFn: async (id: number) => {
-      const { data, error } = await supabase
-        .from('teams')
-        .delete()
-        .eq('id', id)
-        .select()
-        .single();
-      if (error) throw error;
-      return data as Team;
+      const teams = readLocal<Team>('teams')
+      const idx = teams.findIndex((t) => t.id === id)
+      if (idx === -1) throw new Error('Team not found')
+      const [removed] = teams.splice(idx, 1)
+      writeLocal('teams', teams)
+      return removed
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['teams'] }),
   });


### PR DESCRIPTION
## Summary
- replace Supabase data access with localStorage in hooks
- keep React Query invalidation working

## Testing
- `npm run lint`
- `npm test --silent` *(fails: server tests expect auth and network)*

------
https://chatgpt.com/codex/tasks/task_e_68698f6508a483339826eea5d0b0e599