### PR TITLE
Implement localStorage based auth

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,13 +1,13 @@
 
 import { Navigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
-import { supabase, isSupabaseConfigured } from '@/lib/supabase'
+import { isSupabaseConfigured } from '@/lib/supabase'
 import DemoMode from './DemoMode'
 import { isDemoLoggedIn } from '@/lib/demoAuth'
 
 export default function ProtectedRoute({ children }: { children: JSX.Element }) {
   const [loading, setLoading] = useState(true)
-  const [session, setSession] = useState<null | Awaited<ReturnType<typeof supabase.auth.getSession>>['data']['session']>(null)
+  const [session, setSession] = useState<string | null>(null)
   const [hasConfig, setHasConfig] = useState(true)
 
   useEffect(() => {
@@ -19,20 +19,14 @@ export default function ProtectedRoute({ children }: { children: JSX.Element }) 
       return
     }
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, sess) => {
-      setSession(sess)
-      setLoading(false)
-    })
-    
-    supabase.auth.getSession().then(({ data }) => {
-      setSession(data.session)
-      setLoading(false)
-    }).catch(() => {
-      setHasConfig(false);
-      setLoading(false);
-    })
-    
-    return () => { subscription.unsubscribe() }
+    setSession(localStorage.getItem('userSession'))
+    const handler = () => {
+      setSession(localStorage.getItem('userSession'))
+    }
+    window.addEventListener('storage', handler)
+    setLoading(false)
+
+    return () => { window.removeEventListener('storage', handler) }
   }, [])
 
   if (loading) return <div className="min-h-screen flex items-center justify-center">Loading...</div>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,13 +1,17 @@
 import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabase'
 
 export function useAuth() {
-  const [session, setSession] = useState<Awaited<ReturnType<typeof supabase.auth.getSession>>['data']['session'] | null>(null)
+  const [session, setSession] = useState<{ user: { id: string } } | null>(null)
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => setSession(data.session))
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_e, s) => setSession(s))
-    return () => subscription.unsubscribe()
+    const token = localStorage.getItem('userSession')
+    if (token) setSession({ user: { id: token } })
+    const handler = () => {
+      const t = localStorage.getItem('userSession')
+      setSession(t ? { user: { id: t } } : null)
+    }
+    window.addEventListener('storage', handler)
+    return () => window.removeEventListener('storage', handler)
   }, [])
 
   return session

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,8 +1,7 @@
 // src/pages/SignIn.tsx
 import React, { useEffect, useState } from 'react'
-import { supabase, isSupabaseConfigured } from '@/lib/supabase'
+import { isSupabaseConfigured } from '@/lib/supabase'
 import { useNavigate, Link } from 'react-router-dom'
-import AuthFallback from '@/components/AuthFallback'
 import { loginDemo } from '@/lib/demoAuth'
 import {
   Card,
@@ -27,26 +26,17 @@ export default function SignIn() {
     setHasConfig(isSupabaseConfigured())
   }, [])
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  interface StoredUser { id: string; email: string; name?: string; password: string }
+
+  const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    const { data, error } = await supabase.auth.signInWithPassword({ email, password })
-    if (error) {
-      setError(error.message)
+    const users = JSON.parse(localStorage.getItem('users') ?? '[]') as StoredUser[]
+    const user = users.find((u) => u.email === email && u.password === password)
+    if (!user) {
+      setError('Invalid email or password')
       return
     }
-    const userId = data.user?.id
-    if (userId) {
-      await supabase
-        .from('users')
-        .upsert({
-          id: userId,
-          email,
-          name: data.user.user_metadata?.name ?? null,
-          role: 'user',
-          is_active: true,
-          last_login: new Date().toISOString(),
-        })
-    }
+    localStorage.setItem('userSession', user.id)
     navigate('/')
   }
 


### PR DESCRIPTION
## Summary
- replace Supabase auth calls with localStorage logic
- save user data under a `users` key
- keep a `userSession` token for login status

## Testing
- `npm run lint`
- `npm test --silent` *(fails: server and user profile tests)*

------
https://chatgpt.com/codex/tasks/task_e_68698f65a03483338b984a01191ae010