### PR TITLE
Persist constraints in localStorage

### DIFF
--- a/src/lib/localData.ts
+++ b/src/lib/localData.ts
@@ -24,3 +24,8 @@ export const setScores = <T>(val: T) => writeLocal('scores', val);
 
 export const getUsers = <T = unknown[]>(): T => readLocal<T>('users', [] as unknown as T);
 export const setUsers = <T>(val: T) => writeLocal('users', val);
+
+export const getConstraintSettings = <T = unknown>(): T =>
+  readLocal<T>('constraint_settings', {} as unknown as T);
+export const setConstraintSettings = <T>(val: T) =>
+  writeLocal('constraint_settings', val);

--- a/src/lib/pairing/config.ts
+++ b/src/lib/pairing/config.ts
@@ -1,6 +1,9 @@
 // src/lib/settings/loadConstraintSettings.ts
-import { supabase } from '../supabase'
 import defaultConfig from './constraints-config.json'
+import {
+  getConstraintSettings,
+  setConstraintSettings,
+} from '../localData'
 
 export interface ConstraintSettings {
   NoRepeatMatch: boolean
@@ -16,37 +19,18 @@ export interface ConstraintRow {
 }
 
 /**
- * Loads constraint settings from Supabase, falling back to defaults on error.
+ * Load constraint settings from localStorage with defaults.
  */
-export async function loadConstraintSettings(): Promise<ConstraintSettings> {
+export function loadConstraintSettings(): ConstraintSettings {
   try {
-    // Fetch typed rows from the database
-    const { data, error } = await supabase
-      .from('constraint_settings')
-      .select('name, enabled')
-
-    if (error) {
-      throw error
-    }
-    if (!data) {
-      throw new Error('No data returned')
-    }
-
-    // Start with the default JSON configuration
-    const cfg: ConstraintSettings = { ...(defaultConfig as ConstraintSettings) }
-
-    const rows = data as ConstraintRow[]
-
-    // Merge any overrides from the database
-    for (const row of rows) {
-      if (row.name in cfg) {
-        cfg[row.name] = row.enabled
-      }
-    }
-
-    return cfg
+    const stored = getConstraintSettings<Partial<ConstraintSettings>>()
+    return { ...(defaultConfig as ConstraintSettings), ...(stored ?? {}) }
   } catch {
-    // On any failure, return the defaults
     return defaultConfig as ConstraintSettings
   }
+}
+
+/** Persist constraint settings to localStorage. */
+export function saveConstraintSettings(settings: ConstraintSettings): void {
+  setConstraintSettings(settings)
 }

--- a/src/lib/pairing/swiss.ts
+++ b/src/lib/pairing/swiss.ts
@@ -15,7 +15,7 @@ export async function generateSwissPairings(
   rooms: string[] = [],
   judges: string[] = [],
 ): Promise<Pairing[]> {
-  const settings = await loadConstraintSettings();
+  const settings = loadConstraintSettings();
   const active = constraints.filter(c => settings[c.type as keyof typeof settings]);
 
   const sorted = [...teams].sort(


### PR DESCRIPTION
## Summary
- keep constraint settings in localStorage
- remove Supabase dependency from pairing config
- use local constraint settings in Swiss pairing logic

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686bbcc85c288333966b295d7aa07b28