### PR TITLE
Remove Supabase docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ This repository hosts **DebateMinistrator**, a full-stack application for debate
   ```
 
 - Tests are located under `src/**/__tests__`.
-- If tests complain about missing environment variables, copy `.env.example` to `.env` and provide values for `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and related keys.  The backend refuses to start without them.
+- If tests complain about missing environment variables, create an empty `.env` file. Local storage is used for persistence during development.
 
 ## Linting
 - Run `npm run lint` before committing.  Lint errors will cause CI failures.
@@ -28,7 +28,7 @@ This repository hosts **DebateMinistrator**, a full-stack application for debate
 
 ## Typical Issues
 - If the dev server fails after dependency updates, remove `node_modules` and run `npm install` again.
-- Ensure the environment variables in `.env` match those expected by the backend (`VITE_API_BASE_URL`, `VITE_SUPABASE_URL`, etc.).
+- Ensure any custom environment variables in `.env` match those expected by the frontend (`VITE_API_BASE_URL`, etc.).
 
 ## Pull Requests
 - Make small, clear commits with descriptive messages.
@@ -37,7 +37,6 @@ This repository hosts **DebateMinistrator**, a full-stack application for debate
 ## Repository Layout
 - `src/` – React components and utilities.
 - `server/` – **removed**. Pairing logic now lives client side.
-- `supabase/` – Supabase configuration and SQL migrations.
 - `ROADMAP.md` – Long term development plan.
 
 Consult `README.md` for a complete overview of project goals and setup instructions.

--- a/README.md
+++ b/README.md
@@ -146,48 +146,27 @@ DebateMinistrator is a modern, web-based platform designed to streamline the end
 
 ### Environment Variables
 
-1. Copy the example environment file:
+1. Create an optional `.env` file if you need to override defaults:
 
    ```bash
-   cp .env.example .env
+   touch .env
    ```
 
-  After copying, **edit `.env` and fill in `SUPABASE_URL`, `SUPABASE_ANON_KEY`,
-  `VITE_SUPABASE_URL`, and `VITE_SUPABASE_ANON_KEY`**. These correspond to lines
-  5–8 in `.env.example` and are required for the Supabase client to work.
+  No external credentials are required because the app stores data in the
+  browser using **localStorage**.
 
-2. Edit `.env` to configure the Supabase credentials.
+### Local Storage Persistence
 
-   Create a project at [Supabase](https://supabase.com), then copy the **Project URL** and **Anon public key** from the dashboard. Add them to `.env`:
+All tournament data, user accounts and settings are persisted in the browser's
+`localStorage`. Clearing your browser storage resets the application to a clean
+state. During development this removes the need for any external database. The
+hooks under `src/lib/hooks` read and write local data automatically.
 
-   ```
-   SUPABASE_URL=https://avzduledlmahtvmvgnxy.supabase.co
-   SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF2emR1bGVkbG1haHR2bXZnbnh5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk2Njk5ODYsImV4cCI6MjA2NTI0NTk4Nn0.Ni6j-h6oNcDrC8ppCjBZmzciAZhQx8An_GN-o62Jatk
-   VITE_SUPABASE_URL=https://avzduledlmahtvmvgnxy.supabase.co
-   VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImF2emR1bGVkbG1haHR2bXZnbnh5Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk2Njk5ODYsImV4cCI6MjA2NTI0NTk4Nn0.Ni6j-h6oNcDrC8ppCjBZmzciAZhQx8An_GN-o62Jatk
-   ```
+### Admin Account
 
-   The Vite variables are used on the client and should match the server values.
-
-### Supabase Setup
-
-1. Sign in to [Supabase](https://supabase.com) and create a new project.
-2. In your project's **Settings → API** section copy the **Project URL** and **Anon public key**.
-3. Paste those values into the corresponding variables in your `.env` file as shown above.
-4. These variables must be present when building the frontend. They will **not** be injected into the browser unless the same values are duplicated using the `VITE_` prefix.
-5. See [docs/credentials.md](docs/credentials.md) for the default admin login and a list of required environment variables. These must be configured before running `npm run create-admin`.
-6. The login and signup pages require `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to be set in `.env`. If either variable is missing or contains placeholder text, the app displays a “Setup Required” screen (the `AuthFallback` component) instead of the forms.
-7. When deploying to platforms like **Vercel** or **Netlify**, add these environment variables in the platform dashboard and redeploy the application so the build picks them up.
-
-### Creating the Admin User
-
-After configuring `.env`, you can create the default admin account by running:
-
-```bash
-npm run create-admin
-```
-
-This script uses the credentials described in [docs/credentials.md](docs/credentials.md). Provide `SUPABASE_SERVICE_ROLE_KEY` if possible; otherwise it will fall back to the anon key.
+The first time the app loads it creates a default admin account using the
+credentials in [docs/credentials.md](docs/credentials.md). No additional setup is
+required. Clearing browser storage removes this account.
 
 3. **Start the development server:**
    ```bash
@@ -226,11 +205,9 @@ Then execute all unit tests:
 npm test --silent
 ```
 
-This command runs all unit tests including Swiss pairing and bracket generation checks.
-
-For tests that need Supabase, import `test/localStorageSupabase.ts` to use a
-localStorage-backed mock. Call `setMockData()` before each test to seed the
-tables your test expects.
+This command runs all unit tests including Swiss pairing and bracket generation
+checks. Tests that rely on browser storage can use Jest's built-in
+`localStorage` mocks.
 
 ## 🎯 Success Criteria
 
@@ -260,7 +237,7 @@ The platform aims to enable tournament administrators to:
 The **All Tournaments** section of the dashboard lists every event in the
 database. Edit the status field or change settings like `rounds` and
 `elimination` type directly in the list and click **Save**. This issues a
-`PUT /api/tournaments/:id` request so the updates persist in Supabase.
+`PUT /api/tournaments/:id` request so the updates persist in local storage.
 
 ### Phase 3: Real-time Features
 - WebSocket integration

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -18,7 +18,7 @@
 - User role management interface (UI only)
 - Tournament dashboard layout
 - Basic API endpoints
-- Backend database integration via Supabase
+- Local storage persistence layer
 - Authentication system with role-based access
 - API layer refactoring with real queries
 
@@ -39,8 +39,7 @@
 ### Phase 1: Backend Foundation (Weeks 1-3)
 **Priority: HIGH - Critical foundation for all features**
 
-#### 1.1 Database Setup & Integration
-- **Connect Supabase integration** (use Lovable's native Supabase button)
+- **Set up local storage persistence**
 - Design and implement database schema:
   - `tournaments` table (id, name, format, status, settings, created_at)
   - `teams` table (id, tournament_id, name, organization, created_at)
@@ -51,14 +50,12 @@
   - `debate_teams` table (debate_id, team_id, position)
   - `scores` table (id, debate_id, team_id, speaker_id, points, created_at)
 
-#### 1.2 Authentication System
-- Implement Supabase Auth with email/password
+- Implement local authentication with email/password
 - Create protected routes and role-based access control
 - Update DashboardNav to handle real authentication
 - Add user profile management
 
-#### 1.3 API Layer Refactoring
-- Replace mock API with real Supabase queries
+- Replace mock API with local storage calls
 - Implement proper error handling and validation
 - Add data fetching with TanStack Query
 - Create reusable API hooks
@@ -237,8 +234,8 @@
 
 ### Architecture Decisions
 - **State Management:** Continue with TanStack Query for server state
-- **Real-time:** Supabase real-time subscriptions
-- **File Storage:** Supabase Storage for CSV uploads/exports
+- **Real-time:** WebSocket subscriptions
+- **File Storage:** Browser-based CSV imports/exports
 - **Deployment:** Lovable hosting with custom domain options
 
 ### Performance Optimization
@@ -248,7 +245,7 @@
 - Use React.memo and useMemo for expensive computations
 
 ### Security Requirements
-- Row Level Security (RLS) policies in Supabase
+- Client-side access checks
 - Input validation and sanitization
 - Secure file upload handling
 - Rate limiting for API endpoints
@@ -286,18 +283,16 @@
 ## 🚀 Getting Started
 
 ### Immediate Next Steps (Week 1)
-1. **Connect Supabase Integration**
-   - Click the green Supabase button in Lovable
-   - Set up new Supabase project
-   - Configure authentication
+1. **Local Storage Setup**
+   - Ensure the application can read and write to `localStorage`
+   - Seed demo data for development
 
-2. **Database Schema Implementation**
-   - Create initial tables using Supabase dashboard
-   - Set up Row Level Security policies
-   - Test database connections
+2. **Data Structure Implementation**
+   - Define storage keys for tournaments, teams and users
+   - Test persistence by reloading the app
 
 3. **Authentication Integration**
-   - Replace mock authentication with Supabase Auth
+   - Implement simple local credential checks
    - Update DashboardNav component
    - Implement protected routes
 
@@ -313,7 +308,6 @@
 ## 📚 Resources & References
 
 ### Technical Documentation
-- [Supabase Documentation](https://supabase.com/docs)
 - [TanStack Query Guide](https://tanstack.com/query/latest)
 - [Swiss Tournament System](https://en.wikipedia.org/wiki/Swiss-system_tournament)
 - [Debate Tournament Formats](https://worldschoolsdebating.org/formats/)

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,22 +1,11 @@
-# Admin Credentials and Supabase Environment
+# Admin Credentials and Local Storage
 
-The initial admin user credentials are:
+The default admin account uses the following credentials:
 
 - **Email:** `admin@luis.martin`
 - **Password:** `sa1965`
 
-These credentials are required when running the setup script:
-
-```bash
-npm run create-admin
-```
-
-Ensure the following environment variables are configured in your `.env` file before executing this command:
-
-- `SUPABASE_URL`
-- `SUPABASE_ANON_KEY`
-- `VITE_SUPABASE_URL`
-- `VITE_SUPABASE_ANON_KEY`
-- `SUPABASE_SERVICE_ROLE_KEY` (optional)
-
-The values should correspond to your Supabase project. See the README for details on obtaining them.
+During development these values are written to the browser's `localStorage` the
+first time the app runs. Logging in with them works immediately without any
+external setup. Clearing your browser storage removes the account and resets the
+application to its initial state.


### PR DESCRIPTION
## Summary
- document localStorage persistence in README and remove references to Supabase
- update credentials doc to match local storage approach
- drop Supabase setup instructions in AGENTS.md
- clean Supabase references from ROADMAP

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686bbcc99f98833395a2a2280291fe84